### PR TITLE
added --skip-primer-match functionality to skip ngsfilter step

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ These settings control demultiplexing and sequence matching (e.g., allowable PCR
 <small>**`--illumina-demultiplexed`**</small>:  Required if sequencing run is already demultiplexed  
 <small>**`--remove-ambiguous-indices`**</small>:  For previously-demultiplexed sequencing runs, remove reads that have ambiguous indices (i.e. they have bases other than AGCT). This assumes Illumina indices are included in fastq headers:  
     <pre><code>@M02308:1:000000000-KVHGP:1:1101:17168:2066 1:N:0:<strong>CAAWGTGG+TTCNAAGA</strong></code></pre>
+<small>**`--skip-primer-match`**<\small>: Skip primer match and removal (ngsfilter step) if metabarcoding primers were already removed from fastq files (barcode file not used in this case)
 <small>**`--demuxed-fasta [file]`**</small>:  Skip demultiplexing step and use supplied FASTA (must be in usearch/vsearch format). See [above](#demux-fasta).  \
 <small>**`--demuxed-example`**</small>:  Spit out example usearch/vsearch demultiplexed FASTA format  
 <small>**`--demux-only`**</small>:  Stop after demultiplexing and splitting raw reads  

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,6 +42,7 @@ params.sampleMap = ""
 params.minQuality = 20
 params.minAlignLen = 12
 params.minLen = 50
+params.skipPrimerMatch = false
 params.primerMismatch = 2
 
 /* blast query options */


### PR DESCRIPTION
Ok I added this --skip-primer-match option which skips the ngsfilter step completely to solve #68. I added a few words about it in the README, added a reference to it in the config file, and changed only a few lines in the main script. In addition to changing around some stuff with an if argument for the new parameter, I only had to add an intermediate channel and switch the output channel order of a process that was backwards relative to others.

In theory, using this option makes a barcode file unnecessary (tested with a primer-less file), so we could consider making it unnecessary for this set of options (or at least saying blank file/file path is fine) and possibly not even making it an output of the ngsfilter step (as I don't think it's actually needed or used in the following processes)?

Feel free to make any changes to the formatting and order and names or whatever you like of course. I tested it locally on some small files without primers to make sure it worked properly as well but let me know if it needs more or if you needed functional changes too.