### PR TITLE
Bump minimum supported nextflow version

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -1,6 +1,6 @@
-int cores = (int)get_p(params,'maxCpus')
-nextflow.util.MemoryUnit mem = get_p(params,'maxMemory') as nextflow.util.MemoryUnit
-nextflow.util.Duration d = get_p(params,'maxTime') as nextflow.util.Duration
+int cores = (int)params.maxCpus
+nextflow.util.MemoryUnit mem = params.maxMemory as nextflow.util.MemoryUnit
+nextflow.util.Duration d = params.maxTime as nextflow.util.Duration
 insect = get_p(params,"insect")
 blast = get_p(params,"blast")
 demux = get_p(params,"demultiplexedBy") == "index"
@@ -71,7 +71,7 @@ process {
  
 //  // allocate cpus to AdapterRemoval
 // 	withLabel: 'demux_cpus' {
-//     if (get_p(params,'demultiplexedBy') == 'barcode' ) {
+//     if (params.demultiplexedBy == 'barcode' ) {
 //       cpus = cores > 1 ? cores-1 : cores
 //     } else {
 //       cpus = 4 * task.attempt

--- a/conf/base.config
+++ b/conf/base.config
@@ -69,29 +69,16 @@ process {
     maxRetries  = 2
   } 
  
-//  // allocate cpus to AdapterRemoval
-// 	withLabel: 'demux_cpus' {
-//     if (params.demultiplexedBy == 'barcode' ) {
-//       cpus = cores > 1 ? cores-1 : cores
-//     } else {
-//       cpus = 4 * task.attempt
-//     }
-//   }
-
   // allow all cpus
 	withLabel: 'all_cpus' { cpus = { cores } }
 
   // allocate blast cpus
   withLabel: 'blast' {
-    // cpus = { params.insect ? cores / 2 : cores }
-    // memory = { params.insect ? mem / 2 : mem }
     container = 'ncbi/blast:latest'
   }
 
   // alloacte insect cpus
   withLabel: 'insect' {
-    // cpus = { params.blast ? cores / 2 : cores }
-    // memory = { params.blast ? mem / 2 : mem }
     container = 'fishbotherer/r-tools:latest'
   }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
     mainScript = 'rainbow_bridge.nf'
     defaultBranch = 'main'
     version = '1.33.8'
-    nextflowVersion = '!>=24.10.4'
+    nextflowVersion = '!>=25.04.7'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ manifest {
     mainScript = 'rainbow_bridge.nf'
     defaultBranch = 'main'
     version = '1.33.8'
-    nextflowVersion = '!>=22.03'
+    nextflowVersion = '!>=24.10.4'
 }
 
 
@@ -164,53 +164,33 @@ params.maxTime = 240.h
 // ourselves if we want consisistency. what we'll do is give the
 // kebab-case version priority
 
-// convert string to camelCase
-def to_camel(s) {
-  return s.replaceAll(/(?<small>[a-z])-(?<big>[a-z])/) {
-    m,a,b -> a+b.toUpperCase()
-  }
-}
-
-// convert string to kebab-case
-def to_kebab(s) {
-  return s.replaceAll(/([a-z])([A-Z])/,'$1-$2').toLowerCase()
-}
-
-def get_p(p,k) {
-  if (p.containsKey(to_kebab(k))) {
-    return p.get(to_kebab(k))
-  } else {
-    return p.get(k)
-  }
-}
-
 // Function to ensure that resource requirements don't go beyond a maximum limit
 def check_max(obj, type) {
   if (type == 'memory') {
     try {
-      if (obj.compareTo(get_p(params,'maxMemory') as nextflow.util.MemoryUnit) == 1)
-        return get_p(params,'maxMemory') as nextflow.util.MemoryUnit
+      if (obj.compareTo(params.maxMemory as nextflow.util.MemoryUnit) == 1)
+        return params.maxMemory as nextflow.util.MemoryUnit
       else
         return obj
     } catch (all) {
-      println "   ### ERROR ###   Max memory '${get_p(params,'maxMemory')}' is not valid! Using default value: $obj"
+      println "   ### ERROR ###   Max memory '${params.maxMemory}' is not valid! Using default value: $obj"
       return obj
     }
   } else if (type == 'time') {
     try {
-      if (obj.compareTo(get_p(params,'maxTime') as nextflow.util.Duration) == 1)
-        return get_p(params,'maxTime') as nextflow.util.Duration
+      if (obj.compareTo(params.maxTime as nextflow.util.Duration) == 1)
+        return params.maxTime as nextflow.util.Duration
       else
         return obj
     } catch (all) {
-      println "   ### ERROR ###   Max time '${get_p(params,'maxTime')}' is not valid! Using default value: $obj"
+      println "   ### ERROR ###   Max time '${params.maxTime}' is not valid! Using default value: $obj"
       return obj
     }
   } else if (type == 'cpus') {
     try {
-      return Math.min( obj, get_p(params,'maxCpus') as int )
+      return Math.min( obj, params.maxCpus as int )
     } catch (all) {
-      println "   ### ERROR ###   Max cpus '${get_p(params,'maxCpus')}' is not valid! Using default value: $obj"
+      println "   ### ERROR ###   Max cpus '${params.maxCpus}' is not valid! Using default value: $obj"
       return obj
     }
   }
@@ -229,25 +209,22 @@ profiles {
     // make default executor local
     // and limit max cpus to param value
     executor.name = 'local'
-    executor.cpus = (int)get_p(params,'maxCpus')
-    executor.memory = get_p(params,'maxMemory')
+    executor.cpus = (int)params.maxCpus
+    executor.memory = params.maxMemory
 
     singularity {
       /* enable singularity and have it do automounts */
       enabled = true
       autoMounts = true
 
-      String bd = get_p(params,'bindDir')
-      String sc = get_p(params,'singularityCache')
-
       // construct options for singularity bind directories
-      if (bd && bd != '') {
-        runOptions = "-B " + bd.split().join(" -B ")
+      if (params.bindDir && params.bindDir != '') {
+        runOptions = "-B " + params.bindDir.split().join(" -B ")
       }
 
       // set singularity cache directory if specified
-      if (sc && sc != "") {
-        cacheDir = sc
+      if (params.singularityCache && params.singularityCache != "") {
+        cacheDir = params.singularityCache
       }
     }
   }

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -530,8 +530,8 @@ process blast {
 
   // get extra blast options passed on the command line as --blastn-*
   def extra_options = params
-    .findAll { it.key =~ /^blastn-/ }
-    .collectEntries { k, v -> [k.tokenize('-')[1],v] }
+    .findAll { it.key =~ /^blastn[A-Z].+/ }
+    .collectEntries { k, v -> [k.replaceAll(/^blastn/,'').toLowerCase(),v] }
 
   // merge blast options with any extra options
   blast_options = blast_options << extra_options


### PR DESCRIPTION
Bump the minimum supported nextflow version, and change some code (e.g., `get_p` calls) that were hacky solutions to limitations of earlier versions.

Fixes #149 