### PR TITLE
Move extra blast argument processing to config file

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -14,6 +14,17 @@ process {
   withName: 'extract_zip'   { container = 'quay.io/biocontainers/unzip:6.0' }
   withName: 'extract_ncbi_taxonomy' { publishDir = [ path: 'output/taxonomy/ncbi', pattern: '*.zip' ] }
   withName: 'extract_ncbi_taxdb'    { publishDir = [ path: 'output/taxonomy/ncbi', pattern: '*.tar.gz' ] }
+  withName: 'blast' {
+    // get extra blast options passed on the command line as --blastn-*
+    // doing this here avoids caching issues when the overall params map changes
+    ext.blastn_args = { 
+      params
+        .findAll { it.key =~ /^blastn[A-Z].+/ }
+        .collectEntries { k, v -> [k.replaceAll(/^blastn/,'').toLowerCase(),v] }
+        .collect { k, v -> v == true ? "-${k}" : "-${k} ${v}" }
+        .join(" ") 
+    }
+  }
 
   
 

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -533,13 +533,6 @@ process blast {
   blast_options['best_hit_score_edge'] = 0.05
   blast_options['best_hit_overhang'] = 0.25
 
-  // get extra blast options passed on the command line as --blastn-*
-  def extra_options = params
-    .findAll { it.key =~ /^blastn[A-Z].+/ }
-    .collectEntries { k, v -> [k.replaceAll(/^blastn/,'').toLowerCase(),v] }
-
-  // merge blast options with any extra options
-  blast_options = blast_options << extra_options
   // collapse them into a single string
   def blast_opt_str = blast_options
     .collect { k, v -> v == true ? "-${k}" : "-${k} ${v}" }
@@ -559,6 +552,7 @@ process blast {
     -db "${db_name}" \
     -outfmt "6 qseqid sseqid staxid ssciname scomname sskingdom pident length qlen slen mismatch gapopen gaps qstart qend sstart send stitle evalue bitscore qcovs qcovhsp" \
     ${blast_opt_str} \
+    ${task.ext.blastn_args} \
     -query ${zotus_fasta} -num_threads ${task.cpus} \
     > blast_result.tsv
   """


### PR DESCRIPTION
The way `--blastn-xxx` arguments were being processed was breaking nextflow's caching mechanism. Moving the interpretation of those arguments to a config file in a `withName` block solves this.

Fixes #159 