### PR TITLE
Update usearch/vsearch chimera removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,11 +774,11 @@ In both cases, the output from the assignment/LCA operations can be found in the
 ### Denoising/dereplication and zOTU inference
 These options control how (and by what tool) sequences are denoised and zOTUs are inferred By default, rainbow_bridge uses [vsearch](https://github.com/torognes/vsearch) (a free 64-bit clone of usearch), which does not suffer from the 4GB memory limit of the free version of [usearch](https://www.drive5.com/usearch/). You still retain the option of using either the free (32 bit) or commercial (64 bit) versions of usearch, if you really want to. 
 
-<small>**`--denoiser [tool/path]`**</small>:  Sets the tool used for denoising & chimera removal. Accepted options: 'usearch', 'usearch32', 'vsearch', path to 64-bit usearch executable (default: vsearch)    
+<small>**`--denoiser [usearch/vsearch]`**</small>:  Sets the tool used for denoising & chimera removal. Accepted options: 'usearch', 'vsearch' (default: vsearch)    
 <small>**`--min-abundance [num]`**</small>:  Minimum sequence abundance for zOTU determination; sequences with abundances below the specified threshold will be discarded during the denoising process (default: 8)   
 <small>**`--alpha [num]`**</small>: Alpha parameter passed to the UNOISE3 algorithm (see the [unoise2 paper for more info](https://doi.org/10.1101/081257)) (default: 2.0)  
 <small>**`--zotu-identity [num]`**</small>: Fractional pairwise identity used to match raw reads to zOTUs, equivalent to `vsearch` `--id`/`usearch` `-id` parameters (default: 0.97)  
-<small>**`--usearch`**</small>:  Alias for `--denoiser usearch`  
+<small>**`--chimera-ref [file]`**</small>: FASTA file to use in reference-based chimera detection (if omitted, denovo chimera detection will be used). Only available with `vsearch`.  
 
 ### zOTU curation using LULU
 

--- a/lib/helper.groovy
+++ b/lib/helper.groovy
@@ -252,14 +252,12 @@ class helper {
                                     Use with demultiplexed runs lacking primer sequences.
 
     Denoising and zOTU inference:  
-      --denoiser [tool/path]        Sets the tool used for denoising & chimera removal
-                                    accepted options: usearch/usearch32 (equivalent), vsearch, 
-                                    path to usearch64 executable (default: vsearch)
+      --denoiser [usearch/vsearch]  Sets the tool used for denoising & chimera removal (default: vsearch)
       --alpha [num]                 Sets the alpha parameter for the UNOISE3 algorithm (default: ${params.alpha})
       --min-abundance [num]         Minimum sequence abundance for zOTU determination; sequences below threshold will be discarded
                                     (default: ${params.minAbundance}) 
       --zotu-identity [num]         Fractional identity (0–1) for zOTU search (default: 0.97)
-      --usearch                     shortcut for --denoiser usearch
+      --chimera-ref [file]          FASTA file to use in reference-based chimera detection
 
     LULU zOTU curation:
       --lulu                        Curate zOTUs using LULU

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,6 +66,7 @@ params {
   minAbundance = 8
   alpha = 2.0
   zotuIdentity = 0.97
+  chimeraRef = 'nofile-chimera-ref'
 
   /* general script options */
   saveConfig = false

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -386,7 +386,7 @@ process relabel {
   } else {
     """
     # usearch doesn't allow output to stdout so we have to use an intermediate file
-    usearch -fastq_filter ${fastq} -relabel "${key}." -fastaout tmp.fasta 
+    usearch -fastq_filter ${fastq} -relabel "${key}." -fastaout tmp.fasta  -sample "${key}"
     awk '/^>/ {print;} !/^>/ {print(toupper(\$0))}' tmp.fasta > "${key}_relabeled.fasta"
     rm tmp.fasta
     """
@@ -422,38 +422,70 @@ process dereplicate {
   publishDir "${params.outDir}/zotus", mode: params.publishMode
 
   input:
-    tuple val(id), path(relabeled_merged)
+    tuple val(id), path(relabeled_merged), path(chimera_reference)
 
   output:
     tuple val(id), path("${id}_unique.fasta"), path("${id}_zotus.fasta"), path("zotu_table.tsv"), emit: result
     path 'zotu_map.tsv'
+    path 'chimera_map.tsv'
+    path '*_chimera_sequences.fasta'
+    path '*_chimeras_denovo.fasta', optional: true
+    path '*_chimeras_reference.fasta', optional: true
 
   script:
   if (params.denoiser == "vsearch") {
     """
-    # steps:
-    # 1. get unique sequence variants
-    # 2. run denoising algorithm
-    # 3. get rid of chimeras
-    # 4. match original sequences to zotus by 97% identity
     if [ -s "${relabeled_merged}" ]; then
+      # dereplicate to uniques
       vsearch \\
+        --sizeout \\
         --threads ${task.cpus} \\
-        --derep_fulllength ${relabeled_merged} --sizeout \\
+        --derep_fulllength ${relabeled_merged} \\
         --output "${id}_unique.fasta"
+
+      # remove chimeras
+      if [ -f "${chimera_reference}" ]; then
+        # if we have a valid reference file
+        # do reference-based chimera removal in addition to denovo
+        vsearch \\
+          --threads ${task.cpus} \\
+          --uchime3_denovo "${id}_unique.fasta" \\
+          --chimeras "${id}_chimeras_denovo.fasta" \\
+          --nonchimeras - |\\
+          vsearch \\
+            --threads ${task.cpus} \\
+            --uchime_ref - \\
+            --db "${chimera_reference}" \\
+            --nonchimeras "${id}_chimeras_removed.fasta" \\
+            --chimeras "${id}_chimeras_reference.fasta" 
+      else
+        # otherwise just do it denovo
+        vsearch \\
+          --threads ${task.cpus} \\
+          --uchime3_denovo "${id}_unique.fasta" \\
+          --nonchimeras "${id}_chimeras_removed.fasta" \\
+          --uchimeout chimera_map.tsv \\
+          --chimeras "${id}_chimera_sequences.fasta" 
+      fi
+
+      # denoise to zotus
       vsearch \\
         --threads ${task.cpus} \\
-        --cluster_unoise "${id}_unique.fasta" --centroids "${id}_centroids.fasta" \\
-        --minsize ${params.minAbundance} --unoise_alpha ${params.alpha}
-      vsearch \\
-        --threads ${task.cpus} \\
-        --uchime3_denovo "${id}_centroids.fasta" --nonchimeras "${id}_zotus.fasta" \\
+        --cluster_unoise "${id}_chimeras_removed.fasta" \\
+        --centroids "${id}_zotus.fasta" \\
+        --minsize ${params.minAbundance}  \\
+        --unoise_alpha ${params.alpha} \\
         --relabel Zotu
+
+      # generate zotu table
       vsearch \\
         --threads ${task.cpus} \\
-        --usearch_global ${relabeled_merged} --db "${id}_zotus.fasta" \\
-        --id ${params.zotuIdentity} --otutabout zotu_table.tsv \\
-        --userout zotu_map.tsv --userfields "query+target" \\
+        --usearch_global ${relabeled_merged} \\
+        --db "${id}_zotus.fasta" \\
+        --id ${params.zotuIdentity} \\
+        --otutabout zotu_table.tsv \\
+        --userout zotu_map.tsv \\
+        --userfields "query+target" \\
         --top_hits_only
     else
       >&2 echo "Merged FASTA is empty. Did your PCR primers match anything?"
@@ -462,18 +494,35 @@ process dereplicate {
     """
   } else {
     """
-    # steps:
-    # 1. get unique sequences
-    # 2. run denoising & chimera removal
-    # 3. generate zotu table
     if [ -s "${relabeled_merged}" ]; then
-      usearch -fastx_uniques ${relabeled_merged} \\
-        -sizeout -fastaout "${id}_unique.fasta" -threads ${task.cpus}
-      usearch -unoise3 "${id}_unique.fasta"  -zotus "${id}_zotus.fasta"  -threads ${task.cpus} \\
-        -tabbedout "${id}_unique_unoise3.txt" -minsize ${params.minAbundance} \\
+      # dereplicate to uniques
+      usearch \\
+        -fastx_uniques ${relabeled_merged} \\
+        -sizeout \\
+        -fastaout "${id}_unique.fasta" \\
+        -threads ${task.cpus}
+
+      # remove chimeras
+      usearch -uchime3_denovo "${id}_unique.fasta" \\
+        -uchimeout chimera_map.tsv \\
+        -chimeras "${id}_chimera_sequences.fasta" \\
+        -nonchimeras "${id}_chimeras_removed.fasta"
+
+      # denoise to zotus
+      usearch -unoise3 "${id}_unique.fasta"  \\
+        -zotus "${id}_zotus.fasta" \\
+        -threads ${task.cpus} \\
+        -tabbedout zotu_map.tsv \\
+        -minsize ${params.minAbundance} \\
         -unoise_alpha ${params.alpha}
-      usearch -otutab ${relabeled_merged} -id ${params.zotuIdentity} -threads ${task.cpus} \\
-        -zotus ${id}_zotus.fasta -otutabout zotu_table.tsv -mapout zotu_map.tsv
+
+      # generate zotu table
+      usearch -otutab ${relabeled_merged} \\
+        -id ${params.zotuIdentity} \\
+        -threads ${task.cpus} \\
+        -zotus ${id}_zotus.fasta \\
+        -otutabout zotu_table.tsv \\
+        -mapout zotu_map.tsv
     else
       >&2 echo "Merged FASTA is empty. Did your PCR primers match anything?"
       exit 1
@@ -1300,6 +1349,7 @@ workflow {
     // build the channel, run dereplication, and set to a channel we can use again
     Channel.of(params.project) |
       combine(to_dereplicate) |
+      combine(Channel.fromPath(params.chimeraRef)) |
       dereplicate |
       set { dereplicated }
 


### PR DESCRIPTION
Add reference-based chimera removal to vsearch
Rearrange order of zotu generation & chimera removal for vsearch
Actually add chimera detection to usearch
Output various files relevant to chimera detection for both methods.

fixes #170
Finally integrates PR #131 into the main code tree, since it's been languishing in a side branch for a long time now.