### PR TITLE
Update BLAST mechanisms, add features

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Note: a barcode file is optional for demultiplexed runs where PCR primers have a
 
 #### BLAST settings 
 
-For pipeline runs in which BLAST queries are performed, you must identify the database(s) being used. This can be done using the `--blast-db` option and/or the `$FLOW_BLAST` environment variable. See [below](#blast-settings-1) for more details on how to do this. 
+For pipeline runs in which BLAST queries are performed, you must identify the database(s) being used. This is done using the `--blast-db` option. See [below](#blast-settings-1) for more details on how to do this. 
 
 ## Sample IDs
 For non-demultiplexed sequencing runs (`--demultipexed-by barcode`), sample IDs are designated using the `sample` column of the barcode file. For demultiplexed runs (`--demultipexed-by index`), sample IDs are generated using the first (shared) part of the read filename(s) before the fwd/rev (R1/R2) pattern (if applicable). For example, the following read pairs:
@@ -635,31 +635,27 @@ BLAST is an alignment-based approach that uses the NCBI [GenBank](https://www.nc
 
 #### BLAST settings
 
-These settings allow you to control how BLAST searches are performed and specify the location of search databases. The only required option (unless BLAST queries are being skipped) is the location of a local BLAST database, which can be set using the command line option `--blast-db` and/or through the `$FLOW_BLAST` environment variable. Other options in this category allow you to control BLAST search criteria directly (e.g., e-value, percent match, etc.). For further explanation of these options beyond what is described here, see the [blast+ documentation](https://www.ncbi.nlm.nih.gov/books/NBK279690/).
+These settings allow you to control how BLAST searches are performed and specify the location of search databases. The only required option (unless BLAST queries are being skipped) is the location of a local BLAST database, which is set using the command line option `--blast-db`. Other options in this category allow you to control BLAST search criteria directly (e.g., e-value, percent match, etc.). For further explanation of these options beyond what is described here, see the [blast+ documentation](https://www.ncbi.nlm.nih.gov/books/NBK279690/).
 
 The following options are available:  
 
 Specifying your database:  
 <small>**`--blast-db [blast db name]`**</small>: Location of a BLAST database (path *and* name). For example, if the NCBI `nt` database resides at `/usr/local/blast`, use `--blast-db /usr/local/blast/nt`. If you have a custom database called `custom_blast` in `/home/user/customblast`, pass `--blast-db /home/user/customblast/custom_blast`. The "name" of the database is the same as the value passed to the `-out` parameter of `makeblastdb`. If you are unsure of the name of a particular blast database, a good way to identify it is that it's the base name of the .ndb file. For example, if you have a directory with a `fishes.ndb` file, the name of the BLAST database will just be `fishes`.  
 
-By default, `rainbow_bridge` will use the value of the `$FLOW_BLAST` environment variable as the primary BLAST database. If `$FLOW_BLAST` is set, the database it points to will be added in addition to any database(s) passed to `--blast-db`.  
-
 Taxonomic name resolution:  
 BLAST databases use numerical NCBI taxonomy IDs (taxids) to assign taxonomy to sequences. In order for your results to contain the actual scientific names associated with those taxids, the NCBI BLAST taxonomy database (taxdb) must be available to the pipeline. This can be achieved in several ways:   
 
-  - If the taxdb files (`taxdb.btd` and `taxdb.bti`) are present in any of the databases passed through `--blast-db` or `$FLOW_BLAST`, they will be used for all of the supplied databases. 
+  - taxdb files (`taxdb.btd`, `taxdb.bti`, and `taxonomy4blast.sqlite3`) present alongside the database(s) passed using `--blast-db` will be used for queries of those supplied databases. 
     * If you're using one of the NCBI nucleotide databases (e.g., `nt`, `nt_core`, etc.), you most likely already have these files present and won't have to worry about any of this.
-  - If the taxdb files are not found locally, the taxdb archive will be downloaded from the NCBI severs.
-  - Taxonomy files can be explicitly specified using the `--blast-taxdb` option. The option value must point to the `taxdb.tar.gz` archive file containing the relevant files.
+  - Taxonomy files can be explicitly specified using the `--blast-taxdb` option. The option value must point to the `taxdb.tar.gz` archive file containing the relevant files. Note that it is possible to pass URLs to this argument and the file will be downloaded. To download the taxonomy database directly from NCBI, use `--blast-taxdb https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz`.
 
 Multiple BLAST databases:  
-It is possible to query your sequences agains multiple BLAST databases. As mentioned, the pipeline will, by default, use the value of the `$FLOW_BLAST` environment variable as its first BLAST database. If that variable is set, any value(s) passed to `--blast-db` will be added as additional databases. Nextflow does not support multiple values for the same option on the command line (e.g., `workflow.nf --opt val1 --opt val2`), but it *does* support them when using [parameter files](#specifying-parameters-in-a-parameter-file). Thus, if you're not using the `$FLOW_BLAST` variable and/or you want to use multiple custom databases, you'll need to pass them as a list in your parameter file ([see here](#setting-multiple-values-for-the-same-option) for an example). The pipeline will run BLAST queries agains each database separately and merge the results into a common output file.    
+It is possible to query sequences against multiple BLAST databases. Nextflow does not support multiple values for the same option on the command line (e.g., `workflow.nf --opt val1 --opt val2`), but it *does* support them when using [parameter files](#specifying-parameters-in-a-parameter-file). Thus, if you want to use multiple custom databases, you'll need to pass them as a list in your parameter file ([see here](#setting-multiple-values-for-the-same-option) for an example). The pipeline will run BLAST queries against each database separately and merge the results into a common output file.    
 
 All BLAST options:  
 <small>**`--blast`**</small>: Query zOTU sequences against a provided BLAST database.  
-<small>**`--blast-db [blastdb]`**</small>: Specify the location of a BLAST database. The value of this option must be the path and name of a blast database (the 'name' is the basename of the files with the .n\*\* extensions), e.g., /drives/blast/custom_db. If the environment variable `$FLOW_BLAST` is set, its value will be added to the list of databases being searched.   
+<small>**`--blast-db [blastdb]`**</small>: Specify the location of a BLAST database. The value of this option must be the path and name of a blast database (the 'name' is the basename of the files with the .n\*\* extensions), e.g., /drives/blast/custom_db.  
 <small>**`--blast-taxdb [archive]`**</small>: Specify a local taxdb archive. The file passed to this argument must be a .tar.gz archive containing the NCBI taxdb files (`taxdb.btd`, `taxdb.bti`). If these files already occur alongside any of the databases passed to `--blast-db`, they will be reused for all databases. If they are missing entirely, they will be downloaded from the NCBI servers.  
-<small>**`--ignore-blast-env`**</small>: Ignore the value of the `$FLOW_BLAST` environment variable set on the host system when running the pipeline.   
 
 BLAST options passed to the NCBI `blastn` tool:  
 <small>**`--blastn-task [task]`**</small>:  Set blast+ task (default: "blastn"). NCBI `blastn` option: `-task`.  
@@ -954,7 +950,7 @@ If you choose to BLAST your zOTUs, you'll need to provide a path to a local GenB
    
 ## Making a custom BLAST database
 
-It's a well-known fact that DNA barcode reference libraries are incomplete, and you might want to augment them with your own sequencing efforts. Also, sometimes you don't need to query agains the entire NCBI database. In those cases (and maybe some others), you'll probably benefit from using a custom BLAST database. There is plenty of information about this online, but a simple example is provided here. You'll need, at the very minimum, a FASTA file containing your known sequences. If you want those to be assigned taxonomy, you'll need to create a taxonomic ID mapping file. I'll assume you've pulled the blast singularity image [as shown in the previous example](#downloading-the-ncbi-blast-nucleotide-database). For this example, we've sequenced four taxa, which resulted in the following FASTA file (`seqs.fasta`):
+It's a well-known fact that DNA barcode reference libraries are incomplete, and you might want to augment them with your own sequencing efforts. Also, sometimes you don't need to query against the entire NCBI database. In those cases (and maybe some others), you'll probably benefit from using a custom BLAST database. There is plenty of information about this online, but a simple example is provided here. You'll need, at the very minimum, a FASTA file containing your known sequences. If you want those to be assigned taxonomy, you'll need to create a taxonomic ID mapping file. I'll assume you've pulled the blast singularity image [as shown in the previous example](#downloading-the-ncbi-blast-nucleotide-database). For this example, we've sequenced four taxa, which resulted in the following FASTA file (`seqs.fasta`):
 
 ```fasta
 >seq1

--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ To clone the repository and and install dependencies (for running the .nf script
      This will install nextflow and singularity to the system. If this fails, try the instructions given [below](#manual-dependency-installation).
 
 
-To run the pipeline directly from github (note: this method assumes you already have the necessary dependencies installed on the system):
+To run the pipeline directly from github:
 
 ```console
 $ nextflow run -<nextflow-options> mhoban/rainbow_bridge --<rainbow_bridge-options>
 ```
+> [!NOTE]
+> This method assumes you already have the necessary dependencies installed on the system
    
 ### Manual dependency installation
 
@@ -245,7 +247,8 @@ In all cases, if you're processing fastq runs, you must specify the location of 
 
 For paired-end sequencing runs, sequence read filenames must be identical apart from the pattern delineating read direction and all read pairs within a sequencing run must use the same read direction pattern (e.g., 'R1', 'R2'). Thus the following read pairs are supported: `sample1_R1.fastq/sample1_R2.fastq`, `sample1.F.fastq/sample1.R.fastq`, `sample1.1.fastq/sample1.2.fastq`, but the following pairs will fail: `sample1.1.15_R1.fastq/sample1.1.17_R2.fastq`, `sample1.R1.fastq/sample1_R2.fastq`. There are no filename restrictions for single-end sequencing runs.
 
-**Note: when passing file globs as command-line options, make sure that you enclose them in quotes (e.g., `--reads '/storage/sequences/run1/*{R1,R2}*.fastq.gz'`). If you don't, the glob will be expanded by the shell rather than rainbow_bridge and parameter values will be incorrect.**
+> [!NOTE]
+> When passing file globs as command-line options, make sure that you enclose them in quotes (e.g., `--reads '/storage/sequences/run1/*{R1,R2}*.fastq.gz'`). If you don't, the glob will be expanded by the shell rather than rainbow_bridge and parameter values will be incorrect.
 
 
 There are a few ways you can tell rainbow_bridge where your reads are:
@@ -461,7 +464,8 @@ In the example above, there was error output but nothing in the `.command.out` f
 
 A number of rainbow_bridge command-line options accept file globs (wildcards). These are used when you want to indicate more than one file using a matching pattern. For an in-depth treatment of globs in the bash shell environment, have a look [here](https://www.baeldung.com/linux/bash-globbing). For the purposes of this pipeline though, you'll mostly use the following things:
 
-**Note: when passing file globs as command-line options, make sure that you enclose them in quotes (e.g., `--reads '/storage/sequences/run1/*{R1,R2}*.fastq.gz'`). If you don't, the glob will be expanded by the shell rather than rainbow_bridge and parameter values will be incorrect.**
+> [!NOTE]
+> When passing file globs as command-line options, make sure that you enclose them in quotes (e.g., `--reads '/storage/sequences/run1/*{R1,R2}*.fastq.gz'`). If you don't, the glob will be expanded by the shell rather than rainbow_bridge and parameter values will be incorrect.
 
 **\***: a star means 'match any string of characters of any length'  
 For example, the glob 'bc\*.tab' will match any filename that begins with 'bc', followed by a sequence of any characters, and finally ending with '.tab'  
@@ -489,7 +493,8 @@ For fastq-based analyses, you must specify whether the sequencing run is single 
 <small>**`--single`**</small>: denotes single-end sequencing runs  
 <small>**`--paired`**</small>: denotes paired-end sequencing runs  
 
-<small>**Note: one of the above options is required (specifying both will throw an error)**</small>
+> [!NOTE]
+> One of the above options is required (specifying both will throw an error)
 
 ### Specifying demultiplexing strategy
 
@@ -500,7 +505,8 @@ You must also specify the [demultiplexing strategy](#input-requirements) used wh
 ### Other required options
 
 #### Barcode file 
-Note: a barcode file is optional for demultiplexed runs where PCR primers have already been stripped.
+> [!NOTE]
+> A barcode file is optional for demultiplexed runs where PCR primers have already been stripped.
 
 <small>**`--barcode [file/glob]`**</small>: Aside from specifying how to find your sequence reads, you must specify barcode file(s) using the `--barcode` option. If the value passed to `--barcode` is a glob (enclosed in quotes!), rainbow_bridge will use all matching barcode files for demultiplexing/primer matching. Barcode files should comply with the [ngsfilter barcode file format](https://pythonhosted.org/OBITools/scripts/ngsfilter.html), which is a tab-delimited format used to specify sample barcodes and amplicon primers. It will vary slightly based on whether your runs have been demultiplexed by the sequencer or not. Note that the pipeline can perform a few standalone tasks that do not require barcode files (e.g. collapsing taxonomy to LCA or taxonomic classification via insect).
 
@@ -591,7 +597,8 @@ sample_CL1
 sample_CL2
 ```
 
-**NOTE: Make sure the filenames in your sample map match the complete filenames (base names) as they exist on-disk (e.g., if they are gzipped, be sure to include the '.gz' extension in your sample map). This differs from previous versions of the pipeline in which the .gz extension needed to be stripped.**
+> ![NOTE]
+> Make sure the filenames in your sample map match the complete filenames (base names) as they exist on-disk (e.g., if they are gzipped, be sure to include the '.gz' extension in your sample map). This differs from previous versions of the pipeline in which the .gz extension needed to be stripped.
 
 ## Other options
 
@@ -647,7 +654,13 @@ BLAST databases use numerical NCBI taxonomy IDs (taxids) to assign taxonomy to s
 
   - taxdb files (`taxdb.btd`, `taxdb.bti`, and `taxonomy4blast.sqlite3`) present alongside the database(s) passed using `--blast-db` will be used for queries of those supplied databases. 
     * If you're using one of the NCBI nucleotide databases (e.g., `nt`, `nt_core`, etc.), you most likely already have these files present and won't have to worry about any of this.
-  - Taxonomy files can be explicitly specified using the `--blast-taxdb` option. The option value must point to the `taxdb.tar.gz` archive file containing the relevant files. Note that it is possible to pass URLs to this argument and the file will be downloaded. To download the taxonomy database directly from NCBI, use `--blast-taxdb https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz`.
+  - BLAST taxonomy files can be explicitly specified using the `--blast-taxdb` option. The option value must point to the `taxdb.tar.gz` archive file containing the relevant files. Note that it is possible to pass URLs to this argument and the file will be downloaded. To download the taxonomy database directly from NCBI, use `--blast-taxdb https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz`.
+
+Limiting BLAST queries to specific taxonomic groups:  
+NCBI BLAST queries can be limited so that only certain taxa are searched/returned. This works both for "terminal" taxa (i.e. species) and higher-level taxa like families or orders. Traditionally, in order to do this you need to know the numeric NCBI taxonomy id (taxid) of the taxon you're interested in, but rainbow_bridge provides a layer of abstraction that allows you to pass these taxa by name. Thus, if you want a BLAST query to return only animals, you can include the argument `--blast-taxon-filter metazoa` (taxon names are case-insensitive). 
+
+> [!NOTE]
+> If you pass a taxon to `--blast-taxon-filter` that doesn't exist in the BLAST database you're using, you will get an error. In that case you'll see "BLAST Database error: Taxonomy ID(s) not found in the XXX database" in the "Command error" section of the pipeline output (where "XXX" is the name of the BLAST database). If you pass a taxon that just doesn't exist (e.g., "hamburger"), you won't get any errors, the BLAST query just won't be filtered.
 
 Multiple BLAST databases:  
 It is possible to query sequences against multiple BLAST databases. Nextflow does not support multiple values for the same option on the command line (e.g., `workflow.nf --opt val1 --opt val2`), but it *does* support them when using [parameter files](#specifying-parameters-in-a-parameter-file). Thus, if you want to use multiple custom databases, you'll need to pass them as a list in your parameter file ([see here](#setting-multiple-values-for-the-same-option) for an example). The pipeline will run BLAST queries against each database separately and merge the results into a common output file.    
@@ -656,6 +669,7 @@ All BLAST options:
 <small>**`--blast`**</small>: Query zOTU sequences against a provided BLAST database.  
 <small>**`--blast-db [blastdb]`**</small>: Specify the location of a BLAST database. The value of this option must be the path and name of a blast database (the 'name' is the basename of the files with the .n\*\* extensions), e.g., /drives/blast/custom_db.  
 <small>**`--blast-taxdb [archive]`**</small>: Specify a local taxdb archive. The file passed to this argument must be a .tar.gz archive containing the NCBI taxdb files (`taxdb.btd`, `taxdb.bti`). If these files already occur alongside any of the databases passed to `--blast-db`, they will be reused for all databases. If they are missing entirely, they will be downloaded from the NCBI servers.  
+<small>**`--blast-taxon-filter [taxa]`**</small>: Filter your BLAST query by a specific taxon or taxa. The value of this option should be a taxon name (e.g., "Metazoa", "Actinopteri"). Multiple taxa can be passed if separated by commas (e.g., "Metazoa,Rhodophyta") and taxon names are case-insensitive.  
 
 BLAST options passed to the NCBI `blastn` tool:  
 <small>**`--blastn-task [task]`**</small>:  Set blast+ task (default: "blastn"). NCBI `blastn` option: `-task`.  

--- a/lib/helper.groovy
+++ b/lib/helper.groovy
@@ -156,9 +156,13 @@ class helper {
                                     things like custom_db.ndb, custom_db.nhr, custom_db.nin, etc.
                                     To specify multiple BLAST databases, pass them as a list in a
                                     parameters file (see README for more information).
-      --blast-taxdb [file]          Specify local NCBI taxdb.tar.gz file. 
-                                    If unspecified or missing from the --blast-db directory, the pipeline 
-                                    will download these files from the NCBI server.
+      --blast-taxdb [file]          Specify NCBI taxdb.tar.gz file. 
+                                    By default, the pipeline will use any taxdb files that are found
+                                    alongside the specified BLAST databases. If absent, this can be downloaded
+                                    by passing this argument with the URL of the taxdb archive on the NCBI website:
+                                    (https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz)
+      --blast-taxon-filter [taxa]   Limit BLAST query to the specified taxa. Multiple taxa can be passed
+                                    as a comma-separated list.
       --blastn-task [task]          Set blast+ task (default: "blastn")
       --max-query-results [num]     Maxmimum number of BLAST results to return per zOTU (default: 10)
       --percent-identity [num]      Minimum percent identity of matches to report (default: 95)

--- a/lib/helper.groovy
+++ b/lib/helper.groovy
@@ -158,8 +158,10 @@ class helper {
                                     parameters file (see README for more information).
       --blast-taxdb [file]          Specify NCBI taxdb.tar.gz file. 
                                     By default, the pipeline will use any taxdb files that are found
-                                    alongside the specified BLAST databases. If absent, this can be downloaded
-                                    by passing this argument with the URL of the taxdb archive on the NCBI website:
+                                    alongside the specified BLAST databases. If this option is passed,
+                                    the supplied taxdb will be used for ALL blast databases. 
+                                    If a taxdb is missing, it can be downloaded by passing this argument 
+                                    with the URL of the taxdb archive on the NCBI website:
                                     (https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz)
       --blast-taxon-filter [taxa]   Limit BLAST query to the specified taxa. Multiple taxa can be passed
                                     as a comma-separated list.

--- a/lib/helper.groovy
+++ b/lib/helper.groovy
@@ -154,14 +154,11 @@ class helper {
       --blast-db [blastdb]          Location of BLAST database (path AND name).
                                     e.g., '/drive1/blast/custom_db', where the database files are named
                                     things like custom_db.ndb, custom_db.nhr, custom_db.nin, etc.
-                                    If the \$FLOW_BLAST environment variable points to a BLAST database, 
-                                    the pipeline will include it in the list of databases to search.
-                                    To specify multiple BLAST databases, pass them as a list in the
+                                    To specify multiple BLAST databases, pass them as a list in a
                                     parameters file (see README for more information).
       --blast-taxdb [file]          Specify local NCBI taxdb.tar.gz file. 
                                     If unspecified or missing from the --blast-db directory, the pipeline 
                                     will download these files from the NCBI server.
-      --ignore-blast-env            Ignore the value of the \$FLOW_BLAST environment variable
       --blastn-task [task]          Set blast+ task (default: "blastn")
       --max-query-results [num]     Maxmimum number of BLAST results to return per zOTU (default: 10)
       --percent-identity [num]      Minimum percent identity of matches to report (default: 95)

--- a/modules/modules.nf
+++ b/modules/modules.nf
@@ -49,14 +49,15 @@ process extract_zip {
   label 'process_single'
 
   input:
-    tuple path(zipfile), val(f)
+    tuple path(zipfile), val(to_extract)
   output:
-    path(f), emit: file
+    path(to_extract), emit: file
     path(zipfile), emit: zip
   
   script:
+  def arg = to_extract instanceof Collection ? to_extract.collect{ "\"${it}\"" }.join(" ") : "\"${to_extract}\""
   """
-  unzip -p ${zipfile} ${f} > ${f}
+  unzip ${zipfile} ${arg}
   """
 }
 // extract files from a .tar.gz archive
@@ -72,7 +73,8 @@ process extract_targz {
     path(archive), emit: zip
 
   script:
+  def arg = to_extract instanceof Collection ? to_extract.collect{ "\"${it}\"" }.join(" ") : "\"${to_extract}\""
   """
-  gunzip -c ${archive} | tar x ${to_extract}
+  tar -zxf ${archive} ${arg}
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,9 +70,8 @@ params {
 
   /* blast query options */
   blast = false
-  blastTaxdb = 'https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz'
+  blastTaxdb = ''
   blastDb = [] 
-  ignoreBlastEnv = false
   maxQueryResults = 10
   percentIdentity = 95
   evalue = "1e-3"
@@ -84,7 +83,6 @@ params {
 
   /* denoising options */
   denoiser = 'vsearch'  
-  usearch = false
   minAbundance = 8
   alpha = 2.0
   zotuIdentity = 0.97

--- a/nextflow.config
+++ b/nextflow.config
@@ -75,6 +75,7 @@ params {
   maxQueryResults = 10
   percentIdentity = 95
   evalue = "1e-3"
+  blastTaxonFilter = ""
   qcov = 100
 
   blastnTask = "blastn"

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -1472,14 +1472,10 @@ workflow {
       // get unique blast dbs
       blasts = blasts.unique(false)
 
-      // wildcard to capture blast database files
-      def wildcard = "{.n*,.[0-9]*.n*}"
-
-      // collect list of files within blast databases
-      // and group them by blast db names
+      // collect list of blast database files, grouped by database name
       Channel.fromPath(blasts) | 
-        map { [ it.Name, file("${it}*") ] } | 
-        set { blastdb }
+        map { [ it.Name, file("${it}.*") ] } | 
+        set { blastdb } 
 
       if (!helper.file_exists(params.lcaLineage)) {
         // make channel for taxdb files (whether or not they actually exist)
@@ -1509,8 +1505,6 @@ workflow {
           set { tdb }
         blastdb = blastdb.combine(tdb)
       }
-
-      // TODO: there's unmatched braces or something somewhere
 
       // create the blast input channel
       dereplicated |

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -574,6 +574,7 @@ process blast {
 
   input:
     tuple path(zotus_fasta), val(db_name), path(db_files), path(taxdb)
+    val taxids
 
   output:
     path("blast_result.tsv"), emit: result
@@ -601,7 +602,17 @@ process blast {
     .collect { k, v -> v == true ? "-${k}" : "-${k} ${v}" }
     .join(" ")
 
-  def blastn_args = task.ext.blastn_map
+  def blastn_map = task.ext.blastn_map
+  if (taxids instanceof Collection) {
+    taxids = taxids.findAll { it != "" }
+    taxids = taxids.join(",")
+  }
+  if (taxids) {
+    def tt = blastn_map.containsKey('taxids') ? blastn_map['taxids'] : ""
+    blastn_map['taxids'] = ([taxids,tt] - "").join(",")
+  }
+
+  def blastn_args = blastn_map
     .collect { k, v -> v == true ? "-${k}" : "-${k} ${v}" }
     .join(" ") 
   """
@@ -625,6 +636,27 @@ process blast {
     ${blast_opt_str} ${blastn_args} \\
     -query ${zotus_fasta} -num_threads ${task.cpus} \\
     > blast_result.tsv
+  """
+}
+
+// lookup taxids from taxa names
+process lookup_blast_taxids {
+  // label 'r'
+  label 'shell'
+  label 'process_single'
+
+  input:
+    tuple val(taxa), path(ncbi_dumps)
+  output:
+    env(taxids)
+
+  script:
+  if (!(taxa instanceof Collection)) {
+    taxa = [taxa]
+  }
+  def begin = "BEGIN { " + taxa.collect { "spp[\"${it.toLowerCase()}\"] = 1;" }.join(" ") + " }"
+  """
+  taxids=\$(awk -F '\\t' '${begin} (tolower(\$3) in spp && \$7 == "scientific name") {print tolower(\$1)}' names.dmp | sort -n | paste -sd,)
   """
 }
 
@@ -906,7 +938,7 @@ workflow {
 
   def directions = []
   // files to extract from ncbi archives
-  def ncbi_taxdumps = ['merged.dmp','nodes.dmp','taxidlineage.dmp','rankedlineage.dmp']
+  def ncbi_taxdumps = ['merged.dmp','nodes.dmp','taxidlineage.dmp','rankedlineage.dmp', 'names.dmp']
   def ncbi_taxdbs = ['taxdb.bti','taxdb.btd','taxonomy4blast.sqlite3']
 
   // do standalone taxonomy assignment
@@ -1409,7 +1441,7 @@ workflow {
         set { to_dereplicate }
     }
 
-    // build the channel, run dereplication, and set to a channel we can use again
+    // build the input channel, run dereplication, and set to a channel we can use again
     Channel.of(params.project) |
       combine(to_dereplicate) |
       combine(Channel.fromPath(params.chimeraRef)) |
@@ -1418,6 +1450,14 @@ workflow {
 
     dereplicated.result |
       set { dereplicated }
+
+    // load and extract NCBI taxonomy
+    Channel.fromPath(params.ncbiTaxdump,glob:false) |
+      combine(Channel.of(ncbi_taxdumps).toList()) |
+      extract_ncbi_taxonomy 
+    // collate extracted files into a list channel
+    ncbi_dumps = extract_ncbi_taxonomy.out.file |
+      toList
 
     // run blast query, unless skipped
     if (params.blast) {
@@ -1472,14 +1512,27 @@ workflow {
 
       // TODO: there's unmatched braces or something somewhere
 
-      // run the blast query
+      // create the blast input channel
       dereplicated |
         map { sid, uniques, zotus, zotutable -> zotus } |
         combine(blastdb) |
-        blast
+        set { blast_input }
 
-      // since we're now doing blasts separately for each database, combine the results
-      // and store it below each indiviudal database result
+      // lookup filter taxids if necessary
+      if (params.blastTaxonFilter) {
+        Channel.of(params.blastTaxonFilter.split(",")).collect().toList() |
+          combine(ncbi_dumps) | 
+          lookup_blast_taxids |
+          toList |
+          set { blast_taxids }
+      } else {
+        blast_taxids = Channel.of("")
+      }
+
+      // run the blast query
+      blast(blast_input,blast_taxids)
+
+      // merge blast results from different databases
       blast.out.result |
         collect |
         merge_blast |
@@ -1499,15 +1552,6 @@ workflow {
         lulu_blast |
         lulu
     }
-
-    // load and extract NCBI taxonomy
-    Channel.fromPath(params.ncbiTaxdump,glob:false) |
-      combine(Channel.of(ncbi_taxdumps).toList()) |
-      extract_ncbi_taxonomy 
-
-    // collate extracted files into a list channel
-    ncbi_dumps = extract_ncbi_taxonomy.out.file |
-      toList
 
     // run the insect classifier, if so desired
     if (params.insect) {

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -135,30 +135,23 @@ def check_params() {
   // sanity check, blast database
   if (params.blast) {
 
-    // if --blast-taxdb is passed, check that it's a directory and that files exist
-    if (!(params.blastTaxdb =~ /(?i)\.tar\.gz$/)) {
+    // if --blast-taxdb is passed, check that it's a .tar.gz archive
+    if (params.blastTaxdb && !(params.blastTaxdb =~ /(?i)\.tar\.gz$/)) {
       println(colors.bred("--blast-taxdb") + colors.red(" must be a .tar.gz archive"))
       exit(1)
     }
-
-    // get blast environment variable
-    def bdb = helper.get_env("FLOW_BLAST")
 
     // make --blast-db param into a list, if it isn't
     def blasts = params.blastDb
     if (!helper.is_list(blasts))
       blasts = [blasts]
 
-    // if $FLOW_BLAST was set and we're not ignoring it, add it to the front of the list
-    if (bdb != "" && !params.ignoreBlastEnv)
-      blasts = blasts.plus(0,bdb)
-
     // get unique vals
     blasts = blasts.unique(false)
 
     // make sure we've got at least one db
     if (!blasts.size()) {
-      println(colors.red("You must pass at least one value to --blast-db or FLOW_BLAST must point to a valid BLAST database"))
+      println(colors.red("You must pass at least one value to --blast-db"))
       exit(1)
     } else {
       // make sure all dbs exist
@@ -166,7 +159,7 @@ def check_params() {
         if (!file("${it}.ndb").exists()) {
           println(colors.red("Could not find BLAST database '${it}'. Please provide the path to an existing blast database."))
           if (it =~ /~/) {
-            println(colors.yellow("The BLAST database '${it}' contains a '~' that was not expanded by the shell. Try entering an absolute path."))
+            println(colors.yellow("The BLAST database '${it}' contains a tilde ('~') that was not expanded by the shell. Try entering an absolute path."))
           }
           exit(1)
         }
@@ -912,18 +905,20 @@ workflow {
   check_params()
 
   def directions = []
+  // files to extract from ncbi archives
+  def ncbi_taxdumps = ['merged.dmp','nodes.dmp','taxidlineage.dmp','rankedlineage.dmp']
+  def ncbi_taxdbs = ['taxdb.bti','taxdb.btd','taxonomy4blast.sqlite3']
 
   // do standalone taxonomy assignment
   if (params.standaloneTaxonomy) {
 
     // load and extract NCBI taxonomy
     Channel.fromPath(params.ncbiTaxdump,glob:false) |
-      combine(Channel.of('merged.dmp','nodes.dmp','taxidlineage.dmp','rankedlineage.dmp')) |
+      combine(Channel.of(ncbi_taxdumps).toList()) |
       extract_ncbi_taxonomy 
 
     // collate extracted files into a list channel
     ncbi_dumps = extract_ncbi_taxonomy.out.file |
-      collect | 
       toList
 
     // do lca
@@ -1428,18 +1423,11 @@ workflow {
     if (params.blast) {
       // def only works on its own line
       // possibly related to NF issue #804: https://github.com/nextflow-io/nextflow/issues/804
-      def bdb
-      // get $FLOW_BLAST environment variable
-      bdb = helper.get_env("FLOW_BLAST")
 
       // make --blast-db value a list, if it's not already
       def blasts = params.blastDb
       if (!helper.is_list(blasts))
         blasts = [blasts]
-
-      // if $FLOW_BLAST was set and we're not ignoring it, add it to the front of the list
-      if (bdb != "" && !params.ignoreBlastEnv)
-        blasts = blasts.plus(0,bdb)
 
       // get unique blast dbs
       blasts = blasts.unique(false)
@@ -1449,66 +1437,52 @@ workflow {
 
       // collect list of files within blast databases
       // and group them by blast db names
-      blasts.inject(null,{ b,d ->
-        !b ?
-          channel.of(file(d).Name) | combine(channel.fromPath("${d}${wildcard}")) :
-          b | concat(channel.of(file(d).Name) | combine(channel.fromPath("${d}${wildcard}")))
-      }) |
-        groupTuple |
+      Channel.fromPath(blasts) | 
+        map { [ it.Name, file("${it}*") ] } | 
         set { blastdb }
 
       if (!helper.file_exists(params.lcaLineage)) {
-        // try to find taxdb files in any of the supplied blast databases
-        def db = blasts.collect {
-          blastr ->
-            file(blastr).Parent.list().findAll {
-              it =~ /taxdb\.bt[id]/
-            }.collect {
-              "${file(blastr).Parent}/${it}"
-            }
-        }.getAt(0)
+        // make channel for taxdb files (whether or not they actually exist)
 
-        // get taxdb files (either download or from command line)
-        if (db.size() > 0) {
-          // if we found something and we don't want something else, use what we found
-          Channel.fromPath(db) |
-            collect |
-            toList |
-            set { taxdb }
-        } else {
-          // download and extract taxdb from ncbi website
-          Channel.fromPath(params.blastTaxdb,glob:false) |
-            combine(Channel.of('taxdb.btd','taxdb.bti')) |
+        // get taxdb if specified on command line
+        if (params.blastTaxdb) {
+          // stage/download file and extract
+          // glob:false required for URLs to work properly
+          Channel.fromPath(params.blastTaxdb,glob:false) | 
+            combine(Channel.of(ncbi_taxdbs).toList()) |
             extract_ncbi_taxdb
+          // flatten to list
           extract_ncbi_taxdb.out.file |
-            collect |
-            toList | 
-            set { taxdb }  
+            toList |
+            set { tdb }
+          // combine with blast db channel
+          blastdb = blastdb.combine(tdb)
+        } else {
+          // otherwise just assume taxdb files live under each blast db
+          Channel.fromPath(blasts, checkIfExists: false) |
+            map { b -> [b.Name, ncbi_taxdbs.collect{ file("${b.Parent}/${it}") } ] } |
+            set { tdb }
+          blastdb = blastdb.join(tdb)
         }
       } else {
-        Channel.value([[file("taxdb.bti"),file("taxdb.btd")]]) |
-          set { taxdb }
+        Channel.value( [ ncbi_taxdbs.collect{ file(it) } ] ) |
+          set { tdb }
+        blastdb = blastdb.combine(tdb)
       }
+
+      // TODO: there's unmatched braces or something somewhere
 
       // run the blast query
       dereplicated |
         map { sid, uniques, zotus, zotutable -> zotus } |
         combine(blastdb) |
-        combine(taxdb) |
         blast
-
-      // // format output directory name for merged blast results
-      // def pid = String.format("%d",(Integer)num(params.percentIdentity ))
-      // def evalue = String.format("%.3f",num(params.evalue))
-      // def qcov = String.format("%d",(Integer)num(params.qcov))
-      // def blast_dir = "${params.outDir}/blast/pid${pid}_eval${evalue}_qcov${qcov}_max${params.maxQueryResults}"
 
       // since we're now doing blasts separately for each database, combine the results
       // and store it below each indiviudal database result
       blast.out.result |
         collect |
         merge_blast |
-        // collectFile(name: 'blast_result_merged.tsv', storeDir: "${params.outDir}/blast") |
         set { blast_result }
     }
 
@@ -1528,12 +1502,11 @@ workflow {
 
     // load and extract NCBI taxonomy
     Channel.fromPath(params.ncbiTaxdump,glob:false) |
-      combine(Channel.of('merged.dmp','nodes.dmp','taxidlineage.dmp','rankedlineage.dmp')) |
+      combine(Channel.of(ncbi_taxdumps).toList()) |
       extract_ncbi_taxonomy 
 
     // collate extracted files into a list channel
     ncbi_dumps = extract_ncbi_taxonomy.out.file |
-      collect | 
       toList
 
     // run the insect classifier, if so desired

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -656,7 +656,7 @@ process lookup_blast_taxids {
   }
   def begin = "BEGIN { " + taxa.collect { "spp[\"${it.toLowerCase()}\"] = 1;" }.join(" ") + " }"
   """
-  taxids=\$(awk -F '\\t' '${begin} (tolower(\$3) in spp && \$7 == "scientific name") {print tolower(\$1)}' names.dmp | sort -n | paste -sd,)
+  taxids=\$(awk -F '\\t' '${begin} (tolower(\$3) in spp && \$7 == "scientific name") {print \$1}' names.dmp | sort -n | paste -sd,)
   """
 }
 


### PR DESCRIPTION
* De-parallelize zip/tar.gz exraction for NCBI taxonomy
* Redo downloading and extraction of NCBI taxonomy files
* Restructure some of the internals of how BLAST databases are found and passed to input channels
* Add `--blast-taxon-filter` option to limit BLAST queries to specific taxa
* Remove `$FLOW_BLAST` environment variable (and associated `--ignore-blast-env` command line option)
* Update README/command-line documentation

resolves #185