### PR TITLE
Updates to blast command-line options and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ $ nextflow run mhoban/rainbow_bridge \
   --demultiplexed-by index \
   --reads 'reads/*{R1,R2}*.fastq.gz' \
   --barcode barcode.tsv \
-  --blast \
-  --blast-db /path/to/blast/core_nt \
+  --blast /path/to/blast/core_nt \
   --lca
 ```
 
@@ -453,7 +452,7 @@ By default, rainbow_bridge uses [vsearch](https://github.com/torognes/vsearch) t
 
 #### BLAST settings 
 
-For pipeline runs in which BLAST queries are performed, the `--blast` argument is required and you must identify the database(s) being used. This is done using the `--blast-db` option. See [below](#blast-settings-1) for details on how to do this and how to configure BLAST searches. 
+For pipeline runs in which BLAST queries are performed, the `--blast` argument identifies the database(s) being used. See [below](#blast-settings-1) for details on how to do this and how to configure BLAST searches. 
 
 ## General options
 <small>**`--project [project]`**</small>:    Project name, applied as a prefix to various output filenames. (default: project directory name)  
@@ -545,19 +544,17 @@ BLAST is an alignment-based approach that uses a reference database (such as NCB
 
 ### BLAST settings
 
-These settings allow you to control how BLAST searches are performed and specify the location of search databases. The only required option (unless BLAST queries are being skipped) is the location of a local BLAST database, which is set using the command line option `--blast-db`. Other options in this category allow you to control BLAST search criteria directly (e.g., e-value, percent match, etc.). For further explanation of these options beyond what is described here, see the [blast+ documentation](https://www.ncbi.nlm.nih.gov/books/NBK279690/).
-
-First, the command-line option `--blast` must be given to tell rainbow_bridge to run a BLAST search.
+These settings allow you to control how BLAST searches are performed and specify the location of search databases. The only required option is the location of a local BLAST database, which is set using the command line option `--blast`. Other options in this category allow you to control BLAST search criteria directly (e.g., e-value, percent match, etc.). For further explanation of these options beyond what is described here, see the [blast+ documentation](https://www.ncbi.nlm.nih.gov/books/NBK279690/).
 
 The following options are available:  
 
 Specifying your database:  
-<small>**`--blast-db [blast db name]`**</small>: Location of a BLAST database (path *and* name). For example, if the NCBI `nt` database resides at `/usr/local/blast`, use `--blast-db /usr/local/blast/nt`. If you have a custom database called `custom_blast` in `/home/user/customblast`, pass `--blast-db /home/user/customblast/custom_blast`. The "name" of the database is the same as the value passed to the `-out` parameter of `makeblastdb`. If you are unsure of the name of a particular blast database, a good way to identify it is that it's the base name of the .ndb file. For example, if you have a directory with a `fishes.ndb` file, the name of the BLAST database will just be `fishes`.  
+<small>**`--blast [blast db name]`**</small>: Location of a BLAST database (path *and* name). For example, if the NCBI `nt` database resides at `/usr/local/blast`, use `--blast /usr/local/blast/nt`. If you have a custom database called `custom_blast` in `/home/user/customblast`, pass `--blast /home/user/customblast/custom_blast`. The "name" of the database is the same as the value passed to the `-out` parameter of `makeblastdb`. If you are unsure of the name of a particular blast database, a good way to identify it is that it's the base name of the .ndb file. For example, if you have a directory with a `fishes.ndb` file, the name of the BLAST database will just be `fishes`.  
 
 Taxonomic name resolution:  
 BLAST databases use numerical NCBI taxonomy IDs (taxids) to assign taxonomy to sequences. In order for your results to contain the actual scientific names associated with those taxids, the NCBI BLAST taxonomy database (taxdb) must be available to the pipeline. This can be achieved in several ways:   
 
-  - taxdb files (`taxdb.btd`, `taxdb.bti`, and `taxonomy4blast.sqlite3`) present alongside the database(s) passed using `--blast-db` will be used for queries of those supplied databases. 
+  - taxdb files (`taxdb.btd`, `taxdb.bti`, and `taxonomy4blast.sqlite3`) present alongside the database(s) passed using `--blast` will be used for queries of those supplied databases. 
     * If you're using one of the NCBI nucleotide databases (e.g., `nt`, `nt_core`, etc.), you most likely already have these files present and won't have to worry about any of this.
   - The BLAST taxonomy database can be loaded from a local file or downloaded from NCBI's serverse using the `--blast-taxdb` option. Pass with no argument to download or provide the path to `taxdb.tar.gz` to use a local version.
 
@@ -574,14 +571,13 @@ Multiple BLAST databases:
 It is possible to query sequences against multiple BLAST databases. Nextflow does not support multiple values for the same option on the command line (e.g., `workflow.nf --opt val1 --opt val2`), but it *does* support them when using [parameter files](#specifying-parameters-in-a-parameter-file). Thus, if you want to use multiple custom databases, you'll need to pass them as a list in your parameter file ([see here](#setting-multiple-values-for-the-same-option) for an example). The pipeline will run BLAST queries against each database separately and merge the results into a common output file.    
 
 All BLAST options:  
-<small>**`--blast`**</small>: Query sequence variants against a provided BLAST database.  
-<small>**`--blast-db [blastdb]`**</small>: Specify the location of a BLAST database. The value of this option must be the path and name of a blast database (the 'name' is the basename of the files with the .n\*\* extensions), e.g., /drives/blast/custom_db.  
+<small>**`--blast [blastdb]`**</small>: Specify the location of a BLAST database. The value of this option must be the path and name of a blast database (the 'name' is the basename of the files with the .n\*\* extensions), e.g., /drives/blast/custom_db.  
 <small>**`--blast-taxdb [archive]?`**</small>: Specify a local taxdb archive or download from NCBI servers. Pass with no argument to download or provide a path to `taxdb.tar.gz` to use a local copy. By default, rainbow_bridge assumes taxonomy database files exist alongside BLAST database files.  
 <small>**`--blast-taxa [taxa]`**</small>: Limit your BLAST query to a specific taxon or taxa. The value of this option should be a taxon name (e.g., "Metazoa", "Actinopteri"). Multiple taxa can be passed if separated by commas (e.g., "Metazoa,Rhodophyta") and taxon names are case-insensitive.  
 <small>**`--blast-exclude-taxa [taxa]`**</small>: Exclude taxa from BLAST search. Option values have the same requirements as `--blast-taxa`.  
 
 BLAST options passed to the NCBI `blastn` tool:  
-<small>**`--blastn-task [task]`**</small>:  Set blast+ task (default: "blastn"). NCBI `blastn` option: `-task`.  
+<small>**`--blast-task [task]`**</small>:  Set blast+ task (default: "blastn"). NCBI `blastn` option: `-task`.  
 <small>**`--max-query-results [num]`**</small>:  Maximum number of BLAST results to return per query sequence (default: 10). See [here](https://academic.oup.com/bioinformatics/article/35/9/1613/5106166) for important information about this parameter, but mayble also see [here](https://academic.oup.com/bioinformatics/article/35/15/2699/5259186) for a follow-up discussion. NCBI `blastn` option: `-max_target_seqs`.   
 <small>**`--percent-identity [num]`**</small>:  Minimum percent identity of matches (default: 95). NCBI `blastn` option: `-perc_identity`.  
 <small>**`--evalue [num]`**</small>:  BLAST e-value threshold (default: 0.001). NCBI `blastn` option: `-evalue`.   
@@ -1135,7 +1131,7 @@ $ ls -l
 -rw-rw-r-- 1 justaguy justaguy    42 Mar 12 14:27 taxid_map
 ```
 
-In order to use this custom database with rainbow_bridge, if these files reside in a directory called `/users/justaguy/blast`, the value you would pass to `--blast-db` would be `/users/justaguy/blast/custom_database`
+In order to use this custom database with rainbow_bridge, if these files reside in a directory called `/users/justaguy/blast`, the value you would pass to `--blast` would be `/users/justaguy/blast/custom_database`
 
 ## Parameter files
 
@@ -1149,8 +1145,7 @@ barcode: data/barcode.tsv
 remove-ambiguous-indices: true
 lca: true
 primer-mismatch: 3
-blast: true
-blast-db: /opt/blast/nt
+blast: /opt/blast/nt
 ```
 
 and the same thing in json format:
@@ -1163,8 +1158,7 @@ and the same thing in json format:
   "remove-ambiguous-indices": true,
   "lca": true,
   "primer-mismatch": 3,
-  "blast": true,
-  "blast-db": "/opt/blast/nt"
+  "blast": "/opt/blast/nt"
 }
 ```
 
@@ -1186,17 +1180,16 @@ $ nextflow run /path/to/rainbow_bridge.nf \
   --remove-ambiguous-indices \
   --lca \
   --primer-mismatch 3 \
-  --blast \
-  --blast-db /opt/blast/nt
+  --blast /opt/blast/nt
 ```
 
 ### Setting multiple values for the same option
-One advantage of using a parameter file vs. just passing options on the command line is the ability to pass multiple values for the same option (something that isn't supported by nextflow otherwise). In practice, this is only useful for the `--blast-db` option, but if you've got multiple BLAST databases, it becomes critical. To pass multiple values to an option, simply put them in a parameter file and pass them as a list. 
+One advantage of using a parameter file vs. just passing options on the command line is the ability to pass multiple values for the same option (something that isn't supported by nextflow otherwise). In practice, this is only useful for the `--blast` option, but if you've got multiple BLAST databases, it becomes critical. To pass multiple values to an option, simply put them in a parameter file and pass them as a list. 
 
-This is what that looks like in YAML (using `--blast-db` as the example option):  
+This is what that looks like in YAML (using `--blast` as the example option):  
 
 ```yaml
-blast-db:
+blast:
   - /opt/blast/fishes
   - /opt/blast/crabs
   - /opt/blast/snails
@@ -1206,7 +1199,7 @@ And in json:
 
 ```json
 {
-  "blast-db": [
+  "blast": [
     "/opt/blast/fishes",
     "/opt/blast/crabs",
     "/opt/blast/snails"

--- a/lib/helper.groovy
+++ b/lib/helper.groovy
@@ -142,25 +142,22 @@ class helper {
       --min-len [num]               Minimum overall sequence length (default: ${params.minLen})
 
     BLAST settings:
-      --blast                       Query zOTUs against a BLAST database
-      --blast-db [blastdb]          Location of BLAST database (path AND name).
+      --blast [blastdb]             Location of BLAST database (path AND name).
                                     e.g., '/drive1/blast/custom_db', where the database files are named
                                     things like custom_db.ndb, custom_db.nhr, custom_db.nin, etc.
                                     To specify multiple BLAST databases, pass them as a list in a
                                     parameters file (see README for more information).
-      --blast-taxdb [file]          Specify NCBI taxdb.tar.gz file. 
+      --blast-taxdb [file]?         Specify NCBI taxdb.tar.gz file. 
                                     By default, the pipeline will use any taxdb files that are found
-                                    alongside the specified BLAST databases. If this option is passed,
-                                    the supplied taxdb will be used for ALL blast databases. 
-                                    If a taxdb is missing, it can be downloaded by passing this argument 
-                                    with the URL of the taxdb archive on the NCBI website:
-                                    (https://ftp.ncbi.nlm.nih.gov/blast/db/taxdb.tar.gz)
+                                    alongside the existing BLAST databases. Pass this option without
+                                    arguments to download taxdb from the NCBI servers. Otherwise, provide
+                                    a path to a local copy of taxdb.tar.gz.
       --blast-taxa [taxa]           Limit BLAST query to the specified taxa. Multiple taxa can be passed
                                     as a comma-separated list.
       --blast-exclude-taxa [taxa]   Exclude specified taxa from BLAST search. Multiple taxa can be passed
                                     as a comma-separated list.
                                     NOTE: only one of --blast-taxa or --blast-exclude-taxa may be given.
-      --blastn-task [task]          Set blast+ task (default: "blastn")
+      --blast-task [task]           Set blast+ task (default: "blastn")
       --max-query-results [num]     Maxmimum number of BLAST results to return per zOTU (default: 10)
       --percent-identity [num]      Minimum percent identity of matches to report (default: 95)
       --evalue [num]                Expectation value threshold for saving hits (default: 0.001)

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,7 +81,7 @@ params {
   blastExcludeTaxa = ""
   qcov = 100
 
-  blastnTask = "blastn"
+  blastTask = "blastn"
   blastnBest_hit_score_edge = 0.05
   blastnBest_hit_overhang = 0.25
 

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -185,7 +185,7 @@ def check_params() {
       exit(1)
     }
 
-    // make --blast-db param into a list, if it isn't
+    // make --blast param into a list, if it isn't
     def blasts = params.blast
     if (!helper.is_list(blasts))
       blasts = [blasts]
@@ -195,7 +195,7 @@ def check_params() {
 
     // make sure we've got at least one db
     if (!blasts.size()) {
-      println(colors.red("You must pass at least one value to --blast-db"))
+      println(colors.red("You must pass at least one value to --blast"))
       exit(1)
     } else {
       // make sure all dbs exist
@@ -1106,13 +1106,7 @@ process blast {
   blast_options['evalue'] = params.evalue
   blast_options['qcov_hsp_perc'] = params.qcov
   blast_options['max_target_seqs'] = params.maxQueryResults
-  // blast_options['best_hit_score_edge'] = 0.05
-  // blast_options['best_hit_overhang'] = 0.25
-
-  // collapse them into a single string
-  def blast_opt_str = blast_options
-    .collect { k, v -> v == true ? "-${k}" : "-${k} ${v}" }
-    .join(" ")
+  blast_options['task'] = params.blastTask
 
   // get any --blastn-xxx arguments that may exist
   def blastn_map = task.ext.blastn_map
@@ -1125,16 +1119,17 @@ process blast {
     blastn_map[method] = ([taxids,tt] - "").join(",")
   } 
 
-  def blastn_args = blastn_map
+  // collapse them into a single string
+  def blast_opt_str = (blast_options + blastn_map)
     .collect { k, v -> v == true ? "-${k}" : "-${k} ${v}" }
-    .join(" ") 
+    .join(" ")
   """
   # record blast settings
   echo "percent-identity: ${params.percentIdentity}" > settings.yml
   echo "evalue: ${params.evalue}" >> settings.yml
   echo "qcov: ${params.qcov}" >> settings.yml
   echo "max-query-results: ${params.maxQueryResults}" >> settings.yml
-  if [ -n "${blastn_args}" ]; then
+  if [ ${blastn_map.size()} -gt 0 ]; then
     echo "blastn-options:" >> settings.yml
     echo -e "${task.ext.blastn_map.collect { k, v -> "  ${k}: ${v}"}.join("\\n")}" >> settings.yml
   fi
@@ -1146,7 +1141,7 @@ process blast {
   blastn \\
     -db "${db_name}" \\
     -outfmt "6 qseqid sseqid staxid ssciname scomname sskingdom pident length qlen slen mismatch gapopen gaps qstart qend sstart send stitle evalue bitscore qcovs qcovhsp" \\
-    ${blast_opt_str} ${blastn_args} \\
+    ${blast_opt_str} \\
     -query ${zotus_fasta} -num_threads ${task.cpus} \\
     > blast_result.tsv
   """
@@ -2129,7 +2124,7 @@ workflow {
         // def only works on its own line
         // possibly related to NF issue #804: https://github.com/nextflow-io/nextflow/issues/804
 
-        // make --blast-db value a list, if it's not already
+        // make --blast value a list, if it's not already
         def blasts = params.blast
         if (!helper.is_list(blasts))
           blasts = [blasts]


### PR DESCRIPTION
Change `--blastn-task` back to `--blast-task` and update docs
Remove references to `--blast-db` and update docs 