### PR TITLE
Split dereplicate process into individual steps

### DIFF
--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -945,7 +945,7 @@ process merge_relabeled {
   """
 }
 
-// dereplication, chimera removal, zOTU table generation
+// dereplicate to unique sequences
 process dereplicate {
   label 'denoiser'
   label 'process_full'
@@ -953,24 +953,16 @@ process dereplicate {
   publishDir "${params.outDir}/zotus", mode: params.publishMode
 
   input:
-    tuple val(id), path(relabeled_merged), path(chimera_reference)
+    tuple val(id), path(relabeled_merged)
 
   output:
-    tuple val(id), path("${id}_unique.fasta"), path("${id}_zotus.fasta"), path("zotu_table.tsv"), emit: result
+    tuple val(id), path("${id}_unique.fasta"), emit: result
     path 'settings.yml'
-    path 'zotu_map.tsv'
-    path 'chimera_map.tsv'
-    path '*_chimera_sequences.fasta'
-    path '*_chimeras_denovo.fasta', optional: true
-    path '*_chimeras_reference.fasta', optional: true
 
   script:
   if (params.denoiser == "vsearch") {
     """
-    echo 'min-abundance: ${params.minAbundance}' > settings.yml
-    echo 'alpha: ${params.alpha}' >> settings.yml
-    echo 'zotu-identity: ${params.zotuIdentity}' >> settings.yml
-
+    touch settings.yml
     if [ -s "${relabeled_merged}" ]; then
       # dereplicate to uniques
       vsearch \\
@@ -978,51 +970,6 @@ process dereplicate {
         --threads ${task.cpus} \\
         --derep_fulllength ${relabeled_merged} \\
         --output "${id}_unique.fasta"
-
-      # remove chimeras
-      if [ -f "${chimera_reference}" ]; then
-        # if we have a valid reference file
-        # do reference-based chimera removal in addition to denovo
-        vsearch \\
-          --threads ${task.cpus} \\
-          --uchime3_denovo "${id}_unique.fasta" \\
-          --chimeras "${id}_chimeras_denovo.fasta" \\
-          --nonchimeras - |\\
-          vsearch \\
-            --threads ${task.cpus} \\
-            --uchime_ref - \\
-            --db "${chimera_reference}" \\
-            --nonchimeras "${id}_chimeras_removed.fasta" \\
-            --chimeras "${id}_chimeras_reference.fasta" 
-      else
-        # otherwise just do it denovo
-        vsearch \\
-          --threads ${task.cpus} \\
-          --uchime3_denovo "${id}_unique.fasta" \\
-          --nonchimeras "${id}_chimeras_removed.fasta" \\
-          --uchimeout chimera_map.tsv \\
-          --chimeras "${id}_chimera_sequences.fasta" 
-      fi
-
-      # denoise to zotus
-      vsearch \\
-        --threads ${task.cpus} \\
-        --cluster_unoise "${id}_chimeras_removed.fasta" \\
-        --centroids "${id}_zotus.fasta" \\
-        --minsize ${params.minAbundance}  \\
-        --unoise_alpha ${params.alpha} \\
-        --relabel Zotu
-
-      # generate zotu table
-      vsearch \\
-        --threads ${task.cpus} \\
-        --usearch_global ${relabeled_merged} \\
-        --db "${id}_zotus.fasta" \\
-        --id ${params.zotuIdentity} \\
-        --otutabout zotu_table.tsv \\
-        --userout zotu_map.tsv \\
-        --userfields "query+target" \\
-        --top_hits_only
     else
       >&2 echo "Merged FASTA is empty. Did your PCR primers match anything?"
       exit 1
@@ -1030,10 +977,7 @@ process dereplicate {
     """
   } else {
     """
-    echo 'min-abundance: ${params.minAbundance}' > settings.yml
-    echo 'alpha: ${params.alpha}' >> settings.yml
-    echo 'zotu-identity: ${params.zotuIdentity}' >> settings.yml
-
+    touch settings.yml
     if [ -s "${relabeled_merged}" ]; then
       # dereplicate to uniques
       usearch \\
@@ -1041,28 +985,6 @@ process dereplicate {
         -sizeout \\
         -fastaout "${id}_unique.fasta" \\
         -threads ${task.cpus}
-
-      # remove chimeras
-      usearch -uchime3_denovo "${id}_unique.fasta" \\
-        -uchimeout chimera_map.tsv \\
-        -chimeras "${id}_chimera_sequences.fasta" \\
-        -nonchimeras "${id}_chimeras_removed.fasta"
-
-      # denoise to zotus
-      usearch -unoise3 "${id}_unique.fasta"  \\
-        -zotus "${id}_zotus.fasta" \\
-        -threads ${task.cpus} \\
-        -tabbedout zotu_map.tsv \\
-        -minsize ${params.minAbundance} \\
-        -unoise_alpha ${params.alpha}
-
-      # generate zotu table
-      usearch -otutab ${relabeled_merged} \\
-        -id ${params.zotuIdentity} \\
-        -threads ${task.cpus} \\
-        -zotus ${id}_zotus.fasta \\
-        -otutabout zotu_table.tsv \\
-        -mapout zotu_map.tsv
     else
       >&2 echo "Merged FASTA is empty. Did your PCR primers match anything?"
       exit 1
@@ -1070,6 +992,159 @@ process dereplicate {
     """
   }
 }
+
+// remove chimera sequences
+process remove_chimeras {
+  label 'denoiser'
+  label 'process_full'
+
+  publishDir "${params.outDir}/zotus", mode: params.publishMode
+
+  input:
+    tuple val(id), path(uniques), path(chimera_reference)
+
+  output:
+    tuple val(id), path("${id}_chimeras_removed.fasta"), emit: result
+    path 'settings.yml'
+    path 'chimera_map.tsv'
+    path '*_chimera_sequences.fasta'
+    path '*_chimeras_denovo.fasta', optional: true
+    path '*_chimeras_reference.fasta', optional: true
+
+
+  script:
+  if (params.denoiser == "vsearch") {
+    """
+    touch settings.yml
+    # remove chimeras
+    if [ -f "${chimera_reference}" ]; then
+      # if we have a valid reference file
+      # do reference-based chimera removal in addition to denovo
+      vsearch \\
+        --threads ${task.cpus} \\
+        --uchime3_denovo "${uniques}" \\
+        --chimeras "${id}_chimeras_denovo.fasta" \\
+        --nonchimeras - |\\
+        vsearch \\
+          --threads ${task.cpus} \\
+          --uchime_ref - \\
+          --db "${chimera_reference}" \\
+          --nonchimeras "${id}_chimeras_removed.fasta" \\
+          --chimeras "${id}_chimeras_reference.fasta" 
+    else
+      # otherwise just do it denovo
+      vsearch \\
+        --threads ${task.cpus} \\
+        --uchime3_denovo "${uniques}" \\
+        --nonchimeras "${id}_chimeras_removed.fasta" \\
+        --uchimeout chimera_map.tsv \\
+        --chimeras "${id}_chimera_sequences.fasta" 
+    fi
+    """
+  } else {
+    """
+    touch settings.yml
+    # remove chimeras
+    usearch -uchime3_denovo "${uniques}" \\
+      -uchimeout chimera_map.tsv \\
+      -chimeras "${id}_chimera_sequences.fasta" \\
+      -nonchimeras "${id}_chimeras_removed.fasta"
+    """
+  }
+}
+
+// denoise to zotus
+process denoise {
+  label 'denoiser'
+  label 'process_full'
+
+  publishDir "${params.outDir}/zotus", mode: params.publishMode
+
+  input:
+    tuple val(id), path(sequences)
+
+  output:
+    tuple val(id), path("${id}_zotus.fasta"), emit: result
+    path 'settings.yml'
+
+
+  script:
+  if (params.denoiser == "vsearch") {
+    """
+    echo 'min-abundance: ${params.minAbundance}' > settings.yml
+    echo 'alpha: ${params.alpha}' >> settings.yml
+
+    # denoise to zotus
+    vsearch \\
+      --threads ${task.cpus} \\
+      --cluster_unoise "${sequences}" \\
+      --centroids "${id}_zotus.fasta" \\
+      --minsize ${params.minAbundance}  \\
+      --unoise_alpha ${params.alpha} \\
+      --relabel Zotu
+    """
+  } else {
+    """
+    echo 'min-abundance: ${params.minAbundance}' > settings.yml
+    echo 'alpha: ${params.alpha}' >> settings.yml
+
+    # denoise to zotus
+    usearch -unoise3 "${sequences}"  \\
+      -zotus "${id}_zotus.fasta" \\
+      -threads ${task.cpus} \\
+      -minsize ${params.minAbundance} \\
+      -unoise_alpha ${params.alpha}
+    """
+  }
+}
+
+// generate zotu table
+process generate_sequence_table {
+  label 'denoiser'
+  label 'process_full'
+
+  publishDir "${params.outDir}/zotus", mode: params.publishMode
+
+  input:
+    tuple val(id), path(zotus), path(relabeled_merged)
+
+  output:
+    tuple val(id), path('zotu_table.tsv'), emit: result
+    path 'zotu_map.tsv'
+    path 'settings.yml'
+
+
+  script:
+  if (params.denoiser == "vsearch") {
+    """
+    echo 'zotu-identity: ${params.zotuIdentity}' >> settings.yml
+
+    # generate zotu table
+    vsearch \\
+      --threads ${task.cpus} \\
+      --usearch_global "${relabeled_merged}" \\
+      --db "${zotus}" \\
+      --id ${params.zotuIdentity} \\
+      --otutabout zotu_table.tsv \\
+      --userout zotu_map.tsv \\
+      --userfields "query+target" \\
+      --top_hits_only
+    """
+  } else {
+    """
+    echo 'zotu-identity: ${params.zotuIdentity}' >> settings.yml
+
+    # generate zotu table
+    usearch -otutab "${relabeled_merged}" \\
+      -id ${params.zotuIdentity} \\
+      -threads ${task.cpus} \\
+      -zotus "${zotus}" \\
+      -otutabout zotu_table.tsv \\
+      -mapout zotu_map.tsv
+    """
+  }
+}
+
 
 // run blast query
 process blast {
@@ -1862,7 +1937,10 @@ workflow {
           set { to_track }
       }
       dada_track_reads(to_track)
-
+      dada_remove_chimeras.out.asv_table | 
+        set { seq_table }
+      dada_remove_chimeras.out.fasta | 
+        set { sequences }
     } else { // run the u/vsearch pipeline
       if (helper.file_exists(params.sequences)) {
         // we've already demultiplexed and relabeled sequences
@@ -2075,15 +2153,38 @@ workflow {
       }
       
       if (!params.preprocessOnly) {
-        // build the input channel, run dereplication, and set to a channel we can use again
+        // dereplicate
         Channel.of(params.project) |
           combine(to_dereplicate) |
-          combine(Channel.fromPath(params.chimeraRef)) |
           dereplicate |
           set { dereplicated }
 
+        // remove chimeras
         dereplicated.result |
-          set { dereplicated }
+          combine(Channel.fromPath(params.chimeraRef)) |
+          remove_chimeras |
+          set { chimeras_removed }
+
+        // denoise to zotus
+        chimeras_removed.result |
+          denoise | 
+          set { denoised } 
+
+        // generate zotu table
+        denoised.result | 
+          combine(to_dereplicate) |
+          generate_sequence_table | 
+          set { table }
+
+        // set channels used further downstream
+        denoised.result | 
+          map { it[1] } |
+          set { sequences }
+        
+        table.result | 
+          map { it[1] } |
+          set { seq_table }
+
       }
     }
       
@@ -2102,22 +2203,6 @@ workflow {
           ncbi_dumps = Channel.of([ ncbi_taxdumps.collect { file(it) } ])
         }
       }
-
-      // get sequences and sequence table
-      if (params.denoiser == "dada2") {
-        dada_remove_chimeras.out.asv_table | 
-          set { seq_table }
-        dada_remove_chimeras.out.fasta | 
-          set { sequences }
-      } else {
-        dereplicated |
-          map { sid, uniques, zotus, zotutable -> zotutable } |
-          set { seq_table }
-        dereplicated |
-          map { sid, uniques, zotus, zotutable -> zotus } |
-          set { sequences }
-      }
-
 
       // run blast query, unless skipped
       if (params.blast) {


### PR DESCRIPTION
Split `dereplicate` into `dereplicate`, `denoise`, `remove_chimeras`, and `generate_sequence_table`, each with a single usearch/vsearch call.