### PR TITLE
Add opttion to split ASV/ZOTU sequences for parallel taxonomy searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ For more information on the original eDNAFlow pipeline and other software used a
    * [Assigning taxonomy](#assigning-taxonomy)
       + [General taxonomic assignment options](#general-taxonomic-assignment-options)
       + [BLAST settings](#blast-settings-1)
+         - [Taxonomic name resolution](#taxonomic-name-resolution)
+         - [Requiring or excluding taxonomic groups from BLAST searches](#requiring-or-excluding-taxonomic-groups-from-blast-searches)
+         - [Multiple BLAST databases](#multiple-blast-databases)
+         - [All BLAST options](#all-blast-options)
+            * [BLAST options passed to the NCBI `blastn` tool](#blast-options-passed-to-the-ncbi-blastn-tool)
+            * [Customizing other BLAST options](#customizing-other-blast-options)
       + [Classification using insect](#classification-using-insect)
       + [LCA collapse](#lca-collapse)
          - [LCA options](#lca-options)
@@ -540,6 +546,10 @@ BLAST is an alignment-based approach that uses a reference database (such as NCB
 <small>**`--standalone-taxonomy`**</small>: Run standalone insect classification/LCA (requires `--insect` or `--lca` option)  
 <small>**`--ncbi-taxdump [file]`**</small>: Local copy of the NCBI new_taxdump.zip archive (default: downloaded from NCBI server)  
 <small>**`--no-taxdump`**</small>: Suppress downloading of NCBI taxonomy dumps. If this option is passed with `--lca`, a custom lineage (`--lca-lineage`) is required.  
+<small>**`--split-sequences`**</small>: Split sequence variant file and run BLAST and/or insect in parallel. ASVs/ZOTUs FASTA file will be broken up into individual chunks and each chunk will be run through BLAST and/or insect (depending on user selection)  
+<small>**`--split-sequences-by [num]`**</small>: Number of chunks (ASVs/ZOTUs) to include in each split query (default: 200 sequences)  
+<small>**`--split-cpus [num]`**</small>: Number of CPUs to allocate to each individual parallel BLAST and/or insect process (must be less than the value of `--max-cpus`) (default: 1)  
+<small>**`--split-memory [mem]`**</small>: Amount of memory to allocate to each individual parallel BLAST and/or insect process (must be less than the value of `--max-memory`) (default: 2 GB)  
 
 
 ### BLAST settings
@@ -551,14 +561,14 @@ The following options are available:
 Specifying your database:  
 <small>**`--blast [blast db name]`**</small>: Location of a BLAST database (path *and* name). For example, if the NCBI `nt` database resides at `/usr/local/blast`, use `--blast /usr/local/blast/nt`. If you have a custom database called `custom_blast` in `/home/user/customblast`, pass `--blast /home/user/customblast/custom_blast`. The "name" of the database is the same as the value passed to the `-out` parameter of `makeblastdb`. If you are unsure of the name of a particular blast database, a good way to identify it is that it's the base name of the .ndb file. For example, if you have a directory with a `fishes.ndb` file, the name of the BLAST database will just be `fishes`.  
 
-Taxonomic name resolution:  
+#### Taxonomic name resolution
 BLAST databases use numerical NCBI taxonomy IDs (taxids) to assign taxonomy to sequences. In order for your results to contain the actual scientific names associated with those taxids, the NCBI BLAST taxonomy database (taxdb) must be available to the pipeline. This can be achieved in several ways:   
 
   - taxdb files (`taxdb.btd`, `taxdb.bti`, and `taxonomy4blast.sqlite3`) present alongside the database(s) passed using `--blast` will be used for queries of those supplied databases. 
     * If you're using one of the NCBI nucleotide databases (e.g., `nt`, `nt_core`, etc.), you most likely already have these files present and won't have to worry about any of this.
   - The BLAST taxonomy database can be loaded from a local file or downloaded from NCBI's serverse using the `--blast-taxdb` option. Pass with no argument to download or provide the path to `taxdb.tar.gz` to use a local version.
 
-Requiring/excluding specific taxonomic groups from BLAST searches:  
+#### Requiring or excluding taxonomic groups from BLAST searches
 NCBI BLAST queries can be limited so that only certain taxa are searched/returned or that certain taxa are excluded from the results. This works both for "terminal" taxa (species) and higher-level taxa like families or orders. Multiple taxa can be given in a comma-separated list.  
 To limit searches to specific taxa, use the `--blast-taxa` option. For example, if you want a BLAST search to include only animals and red algae, pass the option `--blast-taxa metazoa,rhodophyta`.  
 To exclude taxa from a search, use the `--blast-exclude-taxa` option. For example, `--blast-exclude-taxa bacteria` will exclude all bacteria from a search.   
@@ -567,23 +577,23 @@ Taxon names passed to either option are case-insensitive (i.e,. "Bacteria" and "
 > [!NOTE]
 > If you pass a taxon to `--blast-taxa` that doesn't exist in the BLAST database you're using, you will get an error. In that case you'll see "BLAST Database error: Taxonomy ID(s) not found in the XXX database" in the "Command error" section of the pipeline output (where "XXX" is the name of the BLAST database). If you pass a taxon that just doesn't exist (e.g., "hamburger"), you won't get any errors, the BLAST query just won't be filtered.
 
-Multiple BLAST databases:  
+#### Multiple BLAST databases
 It is possible to query sequences against multiple BLAST databases. Nextflow does not support multiple values for the same option on the command line (e.g., `workflow.nf --opt val1 --opt val2`), but it *does* support them when using [parameter files](#specifying-parameters-in-a-parameter-file). Thus, if you want to use multiple custom databases, you'll need to pass them as a list in your parameter file ([see here](#setting-multiple-values-for-the-same-option) for an example). The pipeline will run BLAST queries against each database separately and merge the results into a common output file.    
 
-All BLAST options:  
+#### All BLAST options
 <small>**`--blast [blastdb]`**</small>: Specify the location of a BLAST database. The value of this option must be the path and name of a blast database (the 'name' is the basename of the files with the .n\*\* extensions), e.g., /drives/blast/custom_db.  
 <small>**`--blast-taxdb [archive]?`**</small>: Specify a local taxdb archive or download from NCBI servers. Pass with no argument to download or provide a path to `taxdb.tar.gz` to use a local copy. By default, rainbow_bridge assumes taxonomy database files exist alongside BLAST database files.  
 <small>**`--blast-taxa [taxa]`**</small>: Limit your BLAST query to a specific taxon or taxa. The value of this option should be a taxon name (e.g., "Metazoa", "Actinopteri"). Multiple taxa can be passed if separated by commas (e.g., "Metazoa,Rhodophyta") and taxon names are case-insensitive.  
 <small>**`--blast-exclude-taxa [taxa]`**</small>: Exclude taxa from BLAST search. Option values have the same requirements as `--blast-taxa`.  
 
-BLAST options passed to the NCBI `blastn` tool:  
+##### BLAST options passed to the NCBI `blastn` tool
 <small>**`--blast-task [task]`**</small>:  Set blast+ task (default: "blastn"). NCBI `blastn` option: `-task`.  
 <small>**`--max-query-results [num]`**</small>:  Maximum number of BLAST results to return per query sequence (default: 10). See [here](https://academic.oup.com/bioinformatics/article/35/9/1613/5106166) for important information about this parameter, but mayble also see [here](https://academic.oup.com/bioinformatics/article/35/15/2699/5259186) for a follow-up discussion. NCBI `blastn` option: `-max_target_seqs`.   
 <small>**`--percent-identity [num]`**</small>:  Minimum percent identity of matches (default: 95). NCBI `blastn` option: `-perc_identity`.  
 <small>**`--evalue [num]`**</small>:  BLAST e-value threshold (default: 0.001). NCBI `blastn` option: `-evalue`.   
 <small>**`--qcov [num]`**</small>:  Minimum percent query coverage (default: 100). NCBI `blastn` option: `-qcov_hsp_perc`.     
 
-Customizing other BLAST options:  
+##### Customizing other BLAST options
 Any [supported command-line option](https://www.ncbi.nlm.nih.gov/books/NBK279684/#_appendices_Options_for_the_commandline_a_) can be passed to the NCBI `blastn` tool by prefacing the option name with `--blastn-` when calling rainbow_bridge:  
 <small>**`--blastn-<blastn_option> [arg]`**</small>:  Pass `<blastn_option>` (and optional orgument) to `blastn` tool.    
 
@@ -591,7 +601,7 @@ For example, the following call:
 ```console
 $ nextflow run /path/to/rainbow_bridge.nf --blastn-gapopen 15 --blastn-gapextend 25 --blastn-html
 ```
-Will result in `blastn` being executed like this:
+Will cause `blastn` to be executed like this:
 ```console
 $ blastn -gapopen 15 -gapextend 25 -html
 ```

--- a/conf/base.config
+++ b/conf/base.config
@@ -39,6 +39,23 @@ process {
         .findAll { it.key =~ /^blastn[A-Z].+/ }
         .collectEntries { k, v -> [k.replaceAll(/^blastn/,'').toLowerCase(),v] }
     }
+
+    // allocate split blast resources if needed
+    cpus = { params.splitSequences ? Math.min(params.splitCpus,params.maxCpus) : params.maxCpus }
+    memory = { 
+      def mm = params.maxMemory as nextflow.util.MemoryUnit
+      def bm = params.splitMemory as nextflow.util.MemoryUnit
+      params.splitSequences ?  (bm.compareTo(mm) < 0 ? bm : mm) : params.maxMemory as nextflow.util.MemoryUnit
+    }
+  }
+  withName: 'insect'{ 
+    // allocate split insect resources if needed
+    cpus = { params.splitSequences ? Math.min(params.splitCpus,params.maxCpus) : params.maxCpus }
+    memory = { 
+      def mm = params.maxMemory as nextflow.util.MemoryUnit
+      def bm = params.splitMemory as nextflow.util.MemoryUnit
+      params.splitSequences ?  (bm.compareTo(mm) < 0 ? bm : mm) : params.maxMemory as nextflow.util.MemoryUnit
+    }
   }
 
   

--- a/lib/helper.groovy
+++ b/lib/helper.groovy
@@ -168,6 +168,10 @@ class helper {
       --standalone-taxonomy         Run LCA and/or insect in standalone mode (independent of pipeline)
       --ncbi-taxdump [file]         Local copy of the NCBI new_taxdump.zip archive (default: downloaded from NCBI server)
       --no-taxdump                  Suppress download of NCBI taxonomy dumps archive
+      --split-sequences             Split sequence variant file and run BLAST and/or insect in parallel
+      --split-sequences-by [num]    Number of sequence records to include in each split query (default: 200)
+      --split-cpus [num]            Number of CPUs to allocate to each split BLAST/insect operation (default: 1)
+      --split-memory [mem]          Memory to allocate to each split BLAST/insect operation (default: 2 GB)
 
     LCA taxonomy collapse:
       --lca                         Collapse assigned BLAST results by least common ancestor (LCA)

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,6 +71,12 @@ params {
   freePrimers = false
   primerMismatch = 2
 
+  /* taxonomic assignment resource options */
+  splitCpus = 1
+  splitMemory = 2.GB
+  splitSequences = false
+  splitSequencesBy = 200
+
   /* blast query options */
   blast = []
   blastTaxdb = false
@@ -80,7 +86,6 @@ params {
   blastTaxa = ""
   blastExcludeTaxa = ""
   qcov = 100
-
   blastTask = "blastn"
   blastnBest_hit_score_edge = 0.05
   blastnBest_hit_overhang = 0.25

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -1164,7 +1164,7 @@ process blast {
     tuple path(zotus_fasta), val(db_name), path(db_files), path(taxdb), val(taxids), val(method)
 
   output:
-    path("blast_result.tsv"), emit: result
+    tuple val(db_name), path("blast_result.tsv"), emit: result
     path 'settings.yml'
 
   script:
@@ -1222,6 +1222,31 @@ process blast {
   """
 }
 
+// merge split blast results
+// it's a process instead of collectFile because it has more than one output directory
+process merge_split_blasts {
+  label 'shell'
+  label 'process_single'
+
+  publishDir { "${params.outDir}/blast/${db_name}" }, mode: params.publishMode
+  publishDir {
+    def pid = String.format("%d",(Integer)num(params.percentIdentity ))
+    def evalue = String.format("%.3f",num(params.evalue))
+    def qcov = String.format("%d",(Integer)num(params.qcov))
+    "${params.outDir}/blast/pid${pid}_eval${evalue}_qcov${qcov}_max${params.maxQueryResults}/${db_name}"
+  }, mode: params.publishMode
+
+  input:
+    tuple val(db_name), path('result*.tsv')
+  output:
+    path('blast_result.tsv')
+
+  script:
+  """
+  cat result*.tsv > blast_result.tsv
+  """
+}
+
 // lookup taxids from taxa names
 process lookup_blast_taxids {
   label 'shell'
@@ -1243,6 +1268,7 @@ process lookup_blast_taxids {
 }
 
 // merge blast results
+// it's a process instead of collectFile because it has more than one output directory
 process merge_blast {
   label 'shell'
   label 'process_single'
@@ -1263,7 +1289,7 @@ process merge_blast {
 
   script:
   """
-  cat staged/*.tsv > blast_result_merged.tsv
+  cat staged/*.tsv | sort -k1,1V > blast_result_merged.tsv
   """
 }
 
@@ -1423,6 +1449,34 @@ process insect {
   """
 }
 
+// merge split insect results
+// it's a process instead of collectFile because it has more than one output directory
+process merge_split_insect {
+  label 'shell'
+  label 'process_single'
+
+  publishDir {
+    def offs = String.format("%d",(Integer)num(params.insectOffset))
+    def thresh = String.format("%.2f",num(params.insectThreshold))
+    def minc = String.format("%d",(Integer)num(params.insectMinCount))
+    def ping = String.format("%.2f",num(params.insectPing))
+    "${params.outDir}/taxonomy/insect/thresh${thresh}_offset${offs}_mincount${minc}_ping${ping}"
+  }, mode: params.publishMode
+  publishDir { "${params.outDir}/taxonomy/insect" }
+
+  input:
+    path('insect*.tsv')
+  output:
+    path('insect_taxonomy.tsv')
+
+  script:
+  """
+  # preserve header
+  head -1 insect1.tsv > insect_taxonomy.tsv
+  tail -qn+2 insect*.tsv | sort -k1,1V >> insect_taxonomy.tsv
+  """
+}
+
 // produce a phyloseq object from pipeline output
 process phyloseq {
   label 'r'
@@ -1572,6 +1626,8 @@ workflow {
         // glob:false is necessary because the urls have question marks in them
         classifier = Channel.fromPath(url, glob:false)
       }
+
+
 
       // run the insect classification
       classifier |
@@ -2204,6 +2260,15 @@ workflow {
         }
       }
 
+      // if requested, split query sequences into chunks
+      if (params.splitSequences) {
+        sequences |
+          splitFasta(by: params.splitSequencesBy, file: true) |
+          set { query_sequences }
+      } else {
+        query_sequences = sequences
+      }
+
       // run blast query, unless skipped
       if (params.blast) {
         // def only works on its own line
@@ -2244,7 +2309,7 @@ workflow {
         }
 
         // create the blast input channel
-        sequences | 
+        query_sequences | 
           combine(blastdb) | 
           set { blast_input }
 
@@ -2265,9 +2330,23 @@ workflow {
         } 
         // run the blast query
         blast(blast_input.combine(blast_taxids))
+        blast_result = blast.out.result
+
+        // merge split blast results by database
+        if (params.splitSequences) {
+          blast_result |
+            groupTuple | 
+            merge_split_blasts |
+            set { blast_result } 
+        } else {
+          // otherwise just get results
+          blast_result | 
+            map { it[1] } |
+            set { blast_result }
+        }
 
         // merge blast results from different databases
-        blast.out.result |
+        blast_result |
           collect |
           merge_blast |
           set { blast_result }
@@ -2298,10 +2377,20 @@ workflow {
 
         // run the insect classification
         classifier |
-          combine(sequences) |
+          combine(query_sequences) |
           combine(ncbi_dumps) |
+          view |
           insect
-        insect_taxonomy = insect.out.taxonomy
+        if (params.splitSequences) {
+          insect.out.taxonomy |
+            toList |
+            view |
+            merge_split_insect |
+            view |
+            set { insect_taxonomy }
+        } else {
+          insect_taxonomy = insect.out.taxonomy
+        }
       } else {
         insect_taxonomy = Channel.fromPath("nofile-insect-taxonomy")
       }

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -2379,14 +2379,11 @@ workflow {
         classifier |
           combine(query_sequences) |
           combine(ncbi_dumps) |
-          view |
           insect
         if (params.splitSequences) {
           insect.out.taxonomy |
             toList |
-            view |
             merge_split_insect |
-            view |
             set { insect_taxonomy }
         } else {
           insect_taxonomy = insect.out.taxonomy


### PR DESCRIPTION
Add --split-sequences, --split-sequences-by, --split-cpus, --split-memory
Splits ASV/ZOTU sequences for parallel BLAST and/or insect search
Assigns resources to parallel insect/BLAST processes.